### PR TITLE
FEMesh Material correctly assigned

### DIFF
--- a/MidasCivil_Adapter/CRUD/PrivateHelpers/GetMaxID.cs
+++ b/MidasCivil_Adapter/CRUD/PrivateHelpers/GetMaxID.cs
@@ -15,7 +15,7 @@ namespace BH.Adapter.MidasCivil
             List<List<string>> delimitted = new List<List<string>>();
             text.ForEach(x =>  delimitted.Add(x.Split(',').ToList()));
 
-            if (text != null)
+            if (!(text.Count() == 0))
             {
                 foreach (List<string> line in delimitted)
                 {

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Elements/Element.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Elements/Element.cs
@@ -70,8 +70,9 @@ namespace BH.Engine.MidasCivil
             }
             else if (feMesh.Nodes.Count == 4)
             {
-                midasElement = (feMesh.CustomData[AdapterId].ToString() + ",PLATE,1," +
+                midasElement = (feMesh.CustomData[AdapterId].ToString() + ",PLATE," +
                     feMesh.Property.CustomData[AdapterId].ToString() + "," +
+                    feMesh.Property.Material.CustomData[AdapterId] + "," +
                   feMesh.Nodes[nodeIndices[0]].CustomData[AdapterId].ToString() + "," +
                   feMesh.Nodes[nodeIndices[1]].CustomData[AdapterId].ToString() + "," +
                   feMesh.Nodes[nodeIndices[2]].CustomData[AdapterId].ToString() + "," +
@@ -79,8 +80,9 @@ namespace BH.Engine.MidasCivil
             }
             else
             {
-                midasElement = (feMesh.CustomData[AdapterId].ToString() + ",PLATE,1," +
+                midasElement = (feMesh.CustomData[AdapterId].ToString() + ",PLATE," +
                     feMesh.Property.CustomData[AdapterId].ToString() + "," +
+                    feMesh.Property.Material.CustomData[AdapterId] + "," +
                  feMesh.Nodes[nodeIndices[0]].CustomData[AdapterId].ToString() + "," +
                  feMesh.Nodes[nodeIndices[1]].CustomData[AdapterId].ToString() + "," +
                  feMesh.Nodes[nodeIndices[2]].CustomData[AdapterId].ToString() + ",0,1,0");

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Properties/Material.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Properties/Material.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.MidasCivil
                 return null; ;
             }
 
-            material.CustomData[AdapterId].ToString();
+            //material.CustomData[AdapterId].ToString();
 
             return midasMaterial;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #149 

<!-- Add short description of what has been fixed -->
Fixed bug where `Material `objects were being incorrectly assigned to `FEMesh `objects in MidasCivil.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EhL5XKIAnx1Ln1zlw3VMo3UBPjpulyPw4n8kOZBHnE1f3w?e=5lmRCj

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed bug where `Material `objects were being incorrectly assigned to `FEMesh `objects in MidasCivil.
