### PR TITLE
Added Support for TimberSection, GenericSection and AluminiumSection, and fixed bug when pulling objects

### DIFF
--- a/MidasCivil_Engine/Convert/ToBHoM/Properties/ToProfile.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Properties/ToProfile.cs
@@ -43,11 +43,15 @@ namespace BH.Engine.MidasCivil
                 double webSpacing = System.Convert.ToDouble(split[18]);
                 double webThickness = System.Convert.ToDouble(split[16]);
                 double corbel;
-
-                if (webSpacing==0)
+                if (System.Math.Abs(width / 2 - webSpacing / 2 - webThickness / 2) < oM.Geometry.Tolerance.Distance)
+                {
                     corbel = 0;
+                }
+
                 else
+                {
                     corbel = width / 2 - webSpacing / 2 - webThickness / 2;
+                }
 
                 bhomProfile = Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(
                         System.Convert.ToDouble(split[14]), width, webThickness,

--- a/MidasCivil_Engine/Convert/ToBHoM/Properties/ToSectionProperty.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Properties/ToSectionProperty.cs
@@ -36,54 +36,61 @@ namespace BH.Engine.MidasCivil
             string[] split = sectionProperty.Split(',');
             string shape = split[12].Trim();
 
-            SteelSection bhomSection = null;
+            GenericSection bhomSection = null;
 
             if (shape == "SB")
             {
                 //    2, DBUSER    , USER-RECTANGLE    , CC, 0, 0, 0, 0, 0, 0, YES, NO, SB , 2, 0.5, 0.5, 0, 0, 0, 0, 0, 0, 0, 0
-                bhomSection = Engine.Structure.Create.SteelRectangleSection(
-                    System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[15]), 0, null);
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(Engine.Structure.Create.RectangleProfile
+                    (System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[15], null), 0), null);
+     
             }
             else if (shape == "B")
             {
                 //    4, DBUSER    , USER-BOX          , CC, 0, 0, 0, 0, 0, 0, YES, NO, B  , 2, 0.5, 0.2, 0.01, 0.02, 0.19, 0.02, 0, 0, 0, 0
-                bhomSection = Engine.Structure.Create.SteelSectionFromProfile(
-                    Engine.MidasCivil.Convert.ToProfile(sectionProperty), null
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(Engine.MidasCivil.Convert.ToProfile(sectionProperty), null
                     );
+  
+                    
             }
             else if (shape == "P")
             {
                 //    6, DBUSER    , CHS 114.3x9.83    , CC, 0, 0, 0, 0, 0, 0, YES, NO, P  , 1, BS, CHS 114.3x9.83
-                bhomSection = Engine.Structure.Create.SteelTubeSection(
-                    System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[15]), null);
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(
+                    Engine.Structure.Create.TubeProfile(System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[15]))
+                    ,null);
+
             }
             else if (shape == "SR")
             {
                 //14, DBUSER    , USER - CIRCLE       , CC, 0, 0, 0, 0, 0, 0, YES, NO, SR , 2, 0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0
-                bhomSection = Engine.Structure.Create.SteelCircularSection(
-                    System.Convert.ToDouble(split[14]), null);
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(
+                    Engine.Structure.Create.CircleProfile(System.Convert.ToDouble(split[14])), null);
+
             }
             else if (shape == "H")
             {
-                bhomSection = Engine.Structure.Create.SteelFabricatedISection(
-                    System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[16]),
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(Engine.Structure.Create.FabricatedISectionProfile
+                    (System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[16]),
                     System.Convert.ToDouble(split[15]), System.Convert.ToDouble(split[17]),
-                    System.Convert.ToDouble(split[18]), System.Convert.ToDouble(split[19]),
-                    0, null);
+                    System.Convert.ToDouble(split[18]), System.Convert.ToDouble(split[19]),0), null);
+
                 //    8, DBUSER    , USER-ISECTION     , CC, 0, 0, 0, 0, 0, 0, YES, NO, H  , 2, 1, 0.3, 0.03, 0.025, 0.5, 0.02, 0.01, 0.01, 0, 0
             }
             else if (shape == "T")
             {
-                bhomSection = Engine.Structure.Create.SteelTSection(
-                    System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[16]),
-                    System.Convert.ToDouble(split[15]), System.Convert.ToDouble(split[17]), 0, 0, null);
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(Engine.Structure.Create.TSectionProfile
+                    (System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[15]),
+                    System.Convert.ToDouble(split[16]), System.Convert.ToDouble(split[17]), 0, 0), null);
+
                 //   10, DBUSER    , USER-TSECTION     , CC, 0, 0, 0, 0, 0, 0, YES, NO, T  , 2, 0.3, 0.2, 0.02, 0.05, 0, 0, 0, 0, 0, 0
             }
             else if (shape == "C")
             {
                 //   12, DBUSER    , USER-CHANNEL      , CC, 0, 0, 0, 0, 0, 0, YES, NO, C  , 2, 0.9, 0.5, 0.02, 0.02, 0.5, 0.02, 0, 0, 0, 0
-                bhomSection = Engine.Structure.Create.SteelSectionFromProfile(
-                        Engine.MidasCivil.Convert.ToProfile(sectionProperty), null);
+
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(Engine.MidasCivil.Convert.ToProfile(sectionProperty), null);
+
 
                 Engine.Reflection.Compute.RecordWarning(bhomSection.SectionProfile.GetType().ToString() +
                     " has identical flanges. Therefore, the top flange width and thickness have been used from MidasCivil.");
@@ -91,7 +98,7 @@ namespace BH.Engine.MidasCivil
             else if (shape == "L")
             {
                 //    1, DBUSER    , USERANGLE         , CC, 0, 0, 0, 0, 0, 0, YES, NO, L  , 2, 0.5, 0.25, 0.01, 0.03, 0, 0, 0, 0, 0, 0
-                bhomSection = Engine.Structure.Create.SteelSectionFromProfile(
+                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(
                         Engine.MidasCivil.Convert.ToProfile(sectionProperty), null);
             }
             else

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Properties/FromMaterial.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Properties/FromMaterial.cs
@@ -60,13 +60,46 @@ namespace BH.Engine.MidasCivil
                     isotropic.PoissonsRatio + "," + isotropic.ThermalExpansionCoeff + "," +
                     isotropic.Density*9.806 + "," + isotropic.Density
                 );
-            }
-            else
-            {
-                Engine.Reflection.Compute.RecordWarning("MidasCivil_Toolkit currently suports Isotropic materials only. No structural properties for material with name " + material.Name + " have been pushed");
-                return null; ;
-            }
 
+
+                
+                string s2 = isotropic.Name;
+                int count2 = 0;
+                foreach (char c in s2)
+                {
+                    count2++;
+                }
+                if (count2 > 16)
+                {
+                    Engine.Reflection.Compute.RecordWarning("All names must be under 16 characters");
+                }
+            }
+            else if(material is IOrthotropic)
+            {
+                IOrthotropic iorthotropic = material as IOrthotropic;
+                midasMaterial = (
+                     iorthotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
+                    iorthotropic.Name + ",0,0,,C,NO," +
+                    iorthotropic.DampingRatio + ",3," 
+                    + iorthotropic.YoungsModulus.X + ","+ iorthotropic.YoungsModulus.Y + "," + iorthotropic.YoungsModulus.Z + ","
+                    + iorthotropic.ThermalExpansionCoeff.X + "," + iorthotropic.ThermalExpansionCoeff.Y + "," + iorthotropic.ThermalExpansionCoeff.Z + ","
+                    + iorthotropic.ShearModulus.X + "," + iorthotropic.ShearModulus.Y + "," + iorthotropic.ShearModulus.Z + ","
+                    + iorthotropic.PoissonsRatio.X + "," + iorthotropic.PoissonsRatio.Y + "," + iorthotropic.PoissonsRatio.Z + ","
+                    + iorthotropic.Density * 9.806 + "," + iorthotropic.Density
+                );
+
+                string s = iorthotropic.Name;
+                int count = 0;
+                foreach (char c in s)
+                {
+                    count++;
+                }
+
+                if (count > 16)
+                {
+                    Engine.Reflection.Compute.RecordWarning("All names must be under 16 characters");
+                }
+            }
             return midasMaterial;
         }
 

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -43,8 +43,20 @@ namespace BH.Engine.MidasCivil
                 string midasSectionProperty = sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
                  sectionProperty.Name + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
                  CreateSection(sectionProperty as dynamic);
+
+                string s3 = sectionProperty.Name;
+                int count3 = 0;
+                foreach (char c in s3)
+                {
+                    count3++;
+                }
+                if (count3 > 16)
+                {
+                    Engine.Reflection.Compute.RecordWarning("All names must be under 16 characters");
+                }
                 return midasSectionProperty;
             }
+
         }
 
         /***************************************************/
@@ -61,6 +73,21 @@ namespace BH.Engine.MidasCivil
         /***************************************************/
 
         private static string CreateSection(ConcreteSection sectionProperty)
+        {
+            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic);
+            return midasSectionProperty;
+        }
+        private static string CreateSection(TimberSection sectionProperty)
+        {
+            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic);
+            return midasSectionProperty;
+        }
+        private static string CreateSection(GenericSection sectionProperty)
+        {
+            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic);
+            return midasSectionProperty;
+        }
+        private static string CreateSection(AluminiumSection sectionProperty)
         {
             string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic);
             return midasSectionProperty;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes  #165 
Closes #179 
<!-- Add short description of what has been fixed -->
Issue #165
Added changes to the following:

Material Properties:
- Added support for `Timber`,`GenericIsotropic` and `Aluminium`  in Push command. 
- Added support for Pulling material properties to ` GenericOrthotropicMaterial` and 
  `GenericIsotropicMaterial`.

Section Properties:
- Added support for `TimberSection`,`GenericSection` and `AluminiumSection`  in Push command. 
- Added support for Pulling section from Midas as `GenericSection` 

Issue #179:
-Fixed FabricatedBoxSection web distance not read correctly.

General:
-Added warnings for all name input over 16 characters.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FMidasCivil%5FToolkit%2FMidasCivil%5FToolkit%2D%23165

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional comments
<!-- As required -->