### PR TITLE
Bug fixes for Property objects assigned to elements

### DIFF
--- a/MidasCivil_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -94,7 +94,7 @@ namespace BH.Engine.MidasCivil
                                     }
                                 }
                             }
-                        support1 = delimitted[15].Trim();
+                            support1 = delimitted[21].Trim();
                             break;
 
                         default:
@@ -120,12 +120,10 @@ namespace BH.Engine.MidasCivil
                                     }
                                 }
                             }
-                            support1 = delimitted[21].Trim();
+                            support1 = delimitted[15].Trim();
                             break;
                     }
                     supportName = support1;
-                    
-
                 }
             }
 

--- a/MidasCivil_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -32,7 +32,6 @@ namespace BH.Engine.MidasCivil
         {
             List<string> delimitted = support.Split(',').ToList();
             string supportName;
-            string support1;
             List<bool> fixity = new List<bool>();
             List<double> stiffness = new List<double>();
 
@@ -94,7 +93,7 @@ namespace BH.Engine.MidasCivil
                                     }
                                 }
                             }
-                            support1 = delimitted[21].Trim();
+                            supportName = delimitted[21].Trim();
                             break;
 
                         default:
@@ -120,10 +119,10 @@ namespace BH.Engine.MidasCivil
                                     }
                                 }
                             }
-                            support1 = delimitted[15].Trim();
+                            supportName = delimitted[15].Trim();
                             break;
                     }
-                    supportName = support1;
+
                 }
             }
 

--- a/MidasCivil_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.MidasCivil
         {
             List<string> delimitted = support.Split(',').ToList();
             string supportName;
-
+            string support1;
             List<bool> fixity = new List<bool>();
             List<double> stiffness = new List<double>();
 
@@ -94,6 +94,7 @@ namespace BH.Engine.MidasCivil
                                     }
                                 }
                             }
+                        support1 = delimitted[15].Trim();
                             break;
 
                         default:
@@ -119,10 +120,11 @@ namespace BH.Engine.MidasCivil
                                     }
                                 }
                             }
+                            support1 = delimitted[21].Trim();
                             break;
                     }
-
-                    supportName = delimitted[15].Trim();
+                    supportName = support1;
+                    
 
                 }
             }

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
@@ -35,27 +35,20 @@ namespace BH.Engine.MidasCivil
         public static string FromFEMesh(this FEMesh feMesh)
         {
             string midasElement = "";
-
             List<int> nodeIndices = feMesh.Faces[0].NodeListIndices;
-            string Prop = "";
-            object Mat = "";
-            if (feMesh.Property == null)
+            string sectionPropertyId = "1";
+            string materialId = "1";
+
+            if (!(feMesh.Property == null))
             {
-                Prop = "1";
-                Mat = "1";
-            }
-            else if (feMesh.Property.Material == null)
-            { Prop = feMesh.Property.CustomData[AdapterIdName].ToString();
-                Mat = "1";
-            }
-            else
+                sectionPropertyId = feMesh.Property.CustomData[AdapterIdName].ToString();
+
+                if (!(feMesh.Property.Material == null))
             {
-                Prop = feMesh.Property.CustomData[AdapterIdName].ToString();
-                Mat = feMesh.Property.Material.CustomData[AdapterIdName];
+                materialId = feMesh.Property.Material.CustomData[AdapterIdName].ToString();
             }
-
-
-
+            }
+         
             if (feMesh.Nodes.Count > 4)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot push mesh with more than 4 nodes");
@@ -63,27 +56,26 @@ namespace BH.Engine.MidasCivil
 
             if (feMesh.Nodes.Count == 4)
             {
-                midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
-                    Prop + "," +
-                    Mat + "," +
+                    midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
+                    sectionPropertyId + "," +
+                    materialId + "," +
                   feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
                   feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
                   feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + "," +
                   feMesh.Nodes[nodeIndices[3]].CustomData[AdapterIdName].ToString() + ",1,0");
             }
             else
-            { midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
-                Prop + "," +
-                Mat + "," +
+            {
+                midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
+                sectionPropertyId + "," +
+                materialId + "," +
              feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
              feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
              feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + ",0,1,0");
-        }
-     
+            }
                 return midasElement;
         }
 
         /***************************************************/
-
     }
 }

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
@@ -44,11 +44,11 @@ namespace BH.Engine.MidasCivil
                 sectionPropertyId = feMesh.Property.CustomData[AdapterIdName].ToString();
 
                 if (!(feMesh.Property.Material == null))
-            {
-                materialId = feMesh.Property.Material.CustomData[AdapterIdName].ToString();
+                {
+                    materialId = feMesh.Property.Material.CustomData[AdapterIdName].ToString();
+                }
             }
-            }
-         
+
             if (feMesh.Nodes.Count > 4)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot push mesh with more than 4 nodes");
@@ -56,13 +56,13 @@ namespace BH.Engine.MidasCivil
 
             if (feMesh.Nodes.Count == 4)
             {
-                    midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
-                    sectionPropertyId + "," +
-                    materialId + "," +
-                  feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
-                  feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
-                  feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + "," +
-                  feMesh.Nodes[nodeIndices[3]].CustomData[AdapterIdName].ToString() + ",1,0");
+                midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
+                sectionPropertyId + "," +
+                materialId + "," +
+              feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
+              feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
+              feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + "," +
+              feMesh.Nodes[nodeIndices[3]].CustomData[AdapterIdName].ToString() + ",1,0");
             }
             else
             {
@@ -73,7 +73,7 @@ namespace BH.Engine.MidasCivil
              feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
              feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + ",0,1,0");
             }
-                return midasElement;
+            return midasElement;
         }
 
         /***************************************************/

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
@@ -48,7 +48,6 @@ namespace BH.Engine.MidasCivil
                     materialId = feMesh.Property.Material.CustomData[AdapterIdName].ToString();
                 }
             }
-
             if (feMesh.Nodes.Count > 4)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot push mesh with more than 4 nodes");
@@ -57,8 +56,8 @@ namespace BH.Engine.MidasCivil
             if (feMesh.Nodes.Count == 4)
             {
                 midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
-                sectionPropertyId + "," +
                 materialId + "," +
+                sectionPropertyId + "," +
               feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
               feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
               feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + "," +
@@ -67,8 +66,8 @@ namespace BH.Engine.MidasCivil
             else
             {
                 midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
-                sectionPropertyId + "," +
                 materialId + "," +
+                sectionPropertyId + "," +
              feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
              feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
              feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + ",0,1,0");

--- a/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
+++ b/MidasCivil_Engine/Convert/ToMidasCivil/Elements/FromFEMesh.cs
@@ -22,7 +22,8 @@
 
 using BH.oM.Structure.Elements;
 using System.Collections.Generic;
-
+using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Structure;
 namespace BH.Engine.MidasCivil
 {
     public static partial class Convert
@@ -34,33 +35,52 @@ namespace BH.Engine.MidasCivil
         public static string FromFEMesh(this FEMesh feMesh)
         {
             string midasElement = "";
+
             List<int> nodeIndices = feMesh.Faces[0].NodeListIndices;
+            string Prop = "";
+            object Mat = "";
+            if (feMesh.Property == null)
+            {
+                Prop = "1";
+                Mat = "1";
+            }
+            else if (feMesh.Property.Material == null)
+            { Prop = feMesh.Property.CustomData[AdapterIdName].ToString();
+                Mat = "1";
+            }
+            else
+            {
+                Prop = feMesh.Property.CustomData[AdapterIdName].ToString();
+                Mat = feMesh.Property.Material.CustomData[AdapterIdName];
+            }
+
+
 
             if (feMesh.Nodes.Count > 4)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot push mesh with more than 4 nodes");
             }
-            else if (feMesh.Nodes.Count == 4)
+
+            if (feMesh.Nodes.Count == 4)
             {
                 midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
-                    feMesh.Property.CustomData[AdapterIdName].ToString() + "," +
-                    feMesh.Property.Material.CustomData[AdapterIdName] + "," +
+                    Prop + "," +
+                    Mat + "," +
                   feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
                   feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
                   feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + "," +
                   feMesh.Nodes[nodeIndices[3]].CustomData[AdapterIdName].ToString() + ",1,0");
             }
             else
-            {
-                midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
-                    feMesh.Property.CustomData[AdapterIdName].ToString() + "," +
-                    feMesh.Property.Material.CustomData[AdapterIdName] + "," +
-                 feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
-                 feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
-                 feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + ",0,1,0");
-            }
-
-            return midasElement;
+            { midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
+                Prop + "," +
+                Mat + "," +
+             feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
+             feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
+             feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + ",0,1,0");
+        }
+     
+                return midasElement;
         }
 
         /***************************************************/

--- a/MidasCivil_Engine/Query/SupportString.cs
+++ b/MidasCivil_Engine/Query/SupportString.cs
@@ -37,21 +37,19 @@ namespace BH.Engine.MidasCivil
 
             string support = "";
 
-            foreach(DOFType freedom in freedoms)
+            foreach (DOFType freedom in freedoms)
             {
-                if(Engine.MidasCivil.Query.SupportedDOFType(freedom))
+                if (Engine.MidasCivil.Query.SupportedDOFType(freedom))
                 {
                     if (freedom == DOFType.Fixed)
                     {
                         support = support + "1";
                     }
-                    else 
-                {
-                    support = support + "0";
+                    else
+                    {
+                        support = support + "0";
+                    }
                 }
-                }
-                
-
             }
             return support;
 

--- a/MidasCivil_Engine/Query/SupportString.cs
+++ b/MidasCivil_Engine/Query/SupportString.cs
@@ -41,18 +41,17 @@ namespace BH.Engine.MidasCivil
             {
                 if(Engine.MidasCivil.Query.SupportedDOFType(freedom))
                 {
-                    Reflection.Compute.RecordWarning(
-                        "Unsupported DOFType in " + constraint6DOF.Name + " assumed to be" + DOFType.Free);
-                    support = support + "0";
-                }
-                else if(freedom == DOFType.Free)
+                    if (freedom == DOFType.Fixed)
+                    {
+                        support = support + "1";
+                    }
+                    else 
                 {
                     support = support + "0";
                 }
-                else if (freedom == DOFType.Fixed)
-                {
-                    support = support + "1";
                 }
+                
+
             }
             return support;
 

--- a/MidasCivil_Engine/Query/SupportString.cs
+++ b/MidasCivil_Engine/Query/SupportString.cs
@@ -45,8 +45,14 @@ namespace BH.Engine.MidasCivil
                     {
                         support = support + "1";
                     }
+                    else if (freedom == DOFType.Free)
+                    {
+                        support = support + "0";
+                    }
                     else
                     {
+                        Reflection.Compute.RecordWarning(
+                                     "Unsupported DOFType in " + constraint6DOF.Name + " assumed to be" + DOFType.Free);
                         support = support + "0";
                     }
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #182
Closes #184 
Closes  #186 
<!-- Add short description of what has been fixed -->
- Fixed bug where `FEmesh `could not be pushed without a `Material` or a `SurfaceProperty` assigned
- Fixed bug where `Constraint6DOF` was not pushing correctly

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FMidasCivil%5FToolkit%2FMidasCivil%5Ftoolkit%2D%23182

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed bug where `FEmesh `could not be pushed without a `Material` or a `SurfaceProperty` assigned
- Fixed bug where `Constraint6DOF` was not pushing correctly
- Fixed bug where `Constraint6DOF` with spring stiffnesses were not read correctly on 8.8.5