### PR TITLE
Add read functionality for NodeResult

### DIFF
--- a/.ci/check-core.yml
+++ b/.ci/check-core.yml
@@ -5,7 +5,6 @@
 
 trigger:
 - master
-pr: master
 
 pool:
   vmImage: 'vs2017-win2016'

--- a/.ci/check-core.yml
+++ b/.ci/check-core.yml
@@ -5,6 +5,7 @@
 
 trigger:
 - master
+pr: master
 
 pool:
   vmImage: 'vs2017-win2016'

--- a/.ci/check-installer.yml
+++ b/.ci/check-installer.yml
@@ -5,6 +5,8 @@
 
 trigger:
 - master
+pr:
+- master
 
 pool:
   vmImage: 'vs2017-win2016'

--- a/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Common;
+using BH.oM.Adapter;
+using BH.oM.Structure.Requests;
+using BH.oM.Structure.Results;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+    {
+
+        /***************************************************/
+        /**** Public method - Read override             ****/
+        /***************************************************/
+
+        public IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
+        {
+            List<IResult> results;
+            List<int> objectIds = GetObjectIDs(request);
+            List<string> loadCases = GetLoadcaseIDs(request);
+
+            switch (request.ResultType)
+            {
+                case BarResultType.BarForce:
+                    results = ExtractBarForce(objectIds, loadCases).ToList();
+                    break;
+                case BarResultType.BarStrain:
+                    results = ExtractBarStrain(objectIds, loadCases).ToList();
+                    break;
+                case BarResultType.BarStress:
+                    results = ExtractBarStress(objectIds, loadCases).ToList();
+                    break;
+                case BarResultType.BarDisplacement:
+                    results = ExtractBarDisplacement(objectIds, loadCases).ToList();
+                    break;
+                default:
+                    Engine.Reflection.Compute.RecordError($"Result of type {request.ResultType} is not yet supported in the MidasCivil_Toolkit.");
+                    results = new List<IResult>();
+                    break;
+            }
+            results.Sort();
+            return results;
+        }
+
+        /***************************************************/
+        /**** Private  Methods                          ****/
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractBarForce(List<int> ids, List<string> loadcaseIds)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractBarStress(List<int> ids, List<string> loadcaseIds)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractBarStrain(List<int> ids, List<string> loadcaseIds)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractBarDisplacement(List<int> ids, List<string> loadcaseIds)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -1,0 +1,99 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Common;
+using BH.oM.Adapter;
+using BH.oM.Structure.Requests;
+using BH.oM.Structure.Results;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+    {
+
+        /***************************************************/
+        /**** Public method - Read override             ****/
+        /***************************************************/
+
+        public IEnumerable<IResult> ReadResults(MeshResultRequest request, ActionConfig actionConfig)
+        {
+            List<IResult> results;
+            List<int> objectIds = GetObjectIDs(request);
+            List<string> loadCases = GetLoadcaseIDs(request);
+
+            switch (request.ResultType)
+            {
+                case MeshResultType.Displacements:
+                    results = ExtractMeshDisplacement(objectIds, loadCases).ToList();
+                    break;
+                case MeshResultType.Forces:
+                    results = ExtractMeshForce(objectIds, loadCases).ToList();
+                    break;
+                case MeshResultType.Stresses:
+                    results = ExtractMeshStress(objectIds, loadCases, request.Layer).ToList();
+                    break;
+                case MeshResultType.VonMises:
+                    results = ExtractMeshVonMises(objectIds, loadCases, request.Layer).ToList();
+                    break;
+                default:
+                    Engine.Reflection.Compute.RecordError($"Result of type {request.ResultType} is not yet supported in the MidasCivil_Toolkit.");
+                    results = new List<IResult>();
+                    break;
+            }
+            results.Sort();
+            return results;
+        }
+
+        /***************************************************/
+        /**** Private  Methods                          ****/
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractMeshDisplacement(List<int> ids, List<string> loadcaseIds)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractMeshForce(List<int> ids, List<string> loadcaseIds)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractMeshStress(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
+        {
+            return null;
+        }
+
+        private IEnumerable<IResult> ExtractMeshVonMises(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -1,0 +1,128 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Common;
+using BH.oM.Adapter;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Requests;
+using BH.oM.Structure.Results;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+    {
+
+        /***************************************************/
+        /**** Public method - Read override             ****/
+        /***************************************************/
+
+        public IEnumerable<IResult> ReadResults(NodeResultRequest request, ActionConfig actionConfig)
+        {
+            List<IResult> results;
+            List<int> objectIds = GetObjectIDs(request);
+            List<string> loadCases = GetLoadcaseIDs(request);
+
+            switch (request.ResultType)
+            {
+                case NodeResultType.NodeReaction:
+                    results = ExtractNodeReaction(objectIds, loadCases).ToList();
+                    break;
+                case NodeResultType.NodeDisplacement:
+                    results = ExtractNodeDisplacement(objectIds, loadCases).ToList();
+                    break;
+                default:
+                    Engine.Reflection.Compute.RecordError($"Result of type {request.ResultType} is not yet supported in the MidasCivil_Toolkit.");
+                    results = new List<IResult>();
+                    break;
+            }
+            results.Sort();
+            return results;
+        }
+
+        /***************************************************/
+        /**** Private  Methods                          ****/
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractNodeReaction(List<int> ids, List<string> loadcaseIds)
+        {
+            string filePath = directory + "\\Reaction(Global).xls";
+            string csvPath = ExcelToCsv(filePath);
+            List<String> nodeReactionText = File.ReadAllLines(csvPath).ToList();
+
+            List<NodeReaction> nodeReactions = new List<NodeReaction>();
+            for (int i = 9; i < nodeReactionText.Count; i++)
+            {
+                List<string> nodeReaction = nodeReactionText[i].Split(',').ToList(); ;
+                if (nodeReactionText[i].Contains("SUMMATION"))
+                {
+                    break;
+                }
+                else
+                {
+                    if (ids.Contains(System.Convert.ToInt32(nodeReaction[2])) && loadcaseIds.Contains(nodeReaction[3]))
+                    {
+                        nodeReactions.Add(Engine.MidasCivil.Convert.ToNodeReaction(nodeReaction));
+                    }
+                }
+
+            }
+
+            return nodeReactions;
+
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractNodeDisplacement(List<int> ids, List<string> loadcaseIds)
+        {
+            string filePath = directory + "\\Displacements(Global).xls";
+            string csvPath = ExcelToCsv(filePath);
+            List<String> nodeDisplacementText = File.ReadAllLines(csvPath).ToList();
+
+            List<NodeDisplacement> nodeDisplacements = new List<NodeDisplacement>();
+            for (int i = 9; i < nodeDisplacementText.Count; i++)
+            {
+                List<string> nodeDisplacement = nodeDisplacementText[i].Split(',').ToList(); ;
+                if (nodeDisplacementText[i].Contains("SUMMATION"))
+                {
+                    break;
+                }
+                else
+                {
+                    if (ids.Contains(System.Convert.ToInt32(nodeDisplacement[2])) && loadcaseIds.Contains(nodeDisplacement[3]))
+                    {
+                        nodeDisplacements.Add(Engine.MidasCivil.Convert.ToNodeDisplacement(nodeDisplacement));
+                    }
+                }
+            }
+
+            return nodeDisplacements;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -1,0 +1,236 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using BH.oM.Base;
+using BH.oM.Adapter;
+using BH.oM.Common;
+using BH.oM.Data.Requests;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Requests;
+using Application = Microsoft.Office.Interop.Excel.Application;
+using Workbook = Microsoft.Office.Interop.Excel.Workbook;
+using Worksheet = Microsoft.Office.Interop.Excel.Worksheet;
+using System.Linq;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+    {
+
+        /***************************************************/
+        /**** Adapter  Methods                          ****/
+        /***************************************************/
+
+        protected override IEnumerable<IResult> ReadResults(Type type, IList ids = null, IList cases = null, int divisions = 5, ActionConfig actionConfig = null)
+        {
+            IResultRequest request = Engine.Structure.Create.IResultRequest(type, ids?.Cast<object>(), cases?.Cast<object>(), divisions);
+
+            if (request != null)
+                return this.ReadResults(request as dynamic, actionConfig);
+            else
+                return new List<IResult>();
+        }
+
+        /***************************************************/
+        /**** Private  Methods - Index checking         ****/
+        /***************************************************/
+
+        private List<int> GetObjectIDs(IResultRequest request)
+        {
+            IList ids = request.ObjectIds;
+
+            if (ids == null || ids.Count == 0)
+            {
+                return GetAllIds(request as dynamic);
+            }
+            else
+            {
+                if (ids is List<string>)
+                    return (ids as List<string>).Select(x => int.Parse(x)).ToList();
+                else if (ids is List<int>)
+                    return ids as List<int>;
+                else if (ids is List<double>)
+                    return (ids as List<double>).Select(x => (int)Math.Round(x)).ToList();
+                else
+                {
+                    List<int> idsOut = new List<int>();
+                    foreach (object o in ids)
+                    {
+                        int id;
+                        object idObj;
+                        if (int.TryParse(o.ToString(), out id))
+                        {
+                            idsOut.Add(id);
+                        }
+                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue(AdapterIdName, out idObj) && int.TryParse(idObj.ToString(), out id))
+                            idsOut.Add(id);
+                    }
+                    return idsOut;
+                }
+            }
+        }
+
+        private List<int> GetAllIds(NodeResultRequest request)
+        {
+            int maxIndex = GetMaxId("NODE");
+
+            List<int> ids = new List<int>();
+            for (int i = 1; i < maxIndex + 1; i++)
+            {
+                ids.Add(i);
+            }
+
+            return ids;
+        }
+
+        /***************************************************/
+
+        private List<int> GetAllIds(BarResultRequest request)
+        {
+            int maxIndex = GetMaxId("ELEMENT");
+
+            List<int> ids = new List<int>();
+            for (int i = 1; i < maxIndex + 1; i++)
+            {
+                ids.Add(i);
+            }
+
+            return ids;
+        }
+
+        /***************************************************/
+
+        private List<int> GetAllIds(MeshResultRequest request)
+        {
+            int maxIndex = GetMaxId("ELEMENT");
+
+            List<int> ids = new List<int>();
+            for (int i = 1; i < maxIndex + 1; i++)
+            {
+                ids.Add(i);
+            }
+
+            return ids;
+        }
+
+        /***************************************************/
+
+        private List<string> GetLoadcaseIDs(IResultRequest request)
+        {
+            IList cases = request.Cases;
+
+            List<string> caseNames = new List<string>();
+
+            if (cases is List<string>)
+                return (cases as List<string>);
+            else if (cases is List<int>)
+            {
+                Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit Loadcases do not have Ids as int, provide Loadcases or names.");
+                return null;
+            }
+
+            else if (cases is List<double>)
+            {
+                Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit Loadcases do not have Ids as doubles, provide Loadcases or names.");
+                return null;
+            }
+
+            else if (cases is List<Loadcase>)
+            {
+                for (int i = 0; i < cases.Count; i++)
+                {
+                    caseNames.Add((cases[i] as Loadcase).Name);
+                }
+            }
+            else if (cases is List<LoadCombination>)
+            {
+                foreach (object lComb in cases)
+                {
+                    foreach (Tuple<double, ICase> lCase in (lComb as LoadCombination).LoadCases)
+                    {
+                        caseNames.Add(lCase.Item2.Name);
+                    }
+                    caseNames.Add((lComb as LoadCombination).Name);
+                }
+            }
+            else
+            {
+                caseNames = GetSectionText("STLDCASE").Select(x => x.Split(',')[0].Trim()).ToList();
+
+                List<string> loadCombinationText = GetSectionText("LOADCOMB");
+                for (int i = 0; i < loadCombinationText.Count; i += 2)
+                {
+                    caseNames.Add(loadCombinationText[i].Split(',')[0].Split('=')[1].Trim());
+                }
+            }
+
+
+            return caseNames;
+        }
+
+        /***************************************************/
+
+        private static string ExcelToCsv(string path)
+        {
+            string csvPath = GetCSVFile(path);
+            if (!(File.Exists(csvPath)))
+            {
+                Application excel = new Application();
+                Workbook xlsFile = excel.Workbooks.Open(path);
+                Worksheet sheet = (Microsoft.Office.Interop.Excel.Worksheet)xlsFile.Sheets[1];
+
+                sheet.SaveAs(
+                    csvPath,
+                    Microsoft.Office.Interop.Excel.XlFileFormat.xlCSV,
+                    Type.Missing,
+                    Type.Missing,
+                    Type.Missing,
+                    Type.Missing,
+                    Microsoft.Office.Interop.Excel.XlSaveAsAccessMode.xlShared,
+                    Type.Missing,
+                    Type.Missing,
+                    Type.Missing
+                );
+
+                xlsFile.Close();
+
+            }
+
+            return csvPath;
+        }
+
+        /***************************************************/
+
+        private static string GetCSVFile(string path)
+        {
+            return Path.GetDirectoryName(path) + "\\" + Path.GetFileNameWithoutExtension(path) + ".csv";
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -58,6 +58,10 @@
       <HintPath>..\..\BHoM\Build\Common_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Data_oM">
+      <HintPath>..\..\BHoM\Build\Data_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Dimensional_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>
@@ -70,6 +74,10 @@
     <Reference Include="Geometry_oM">
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Office.Interop.Excel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>
@@ -143,6 +151,10 @@
     <Compile Include="CRUD\Delete\Properties\BarReleases.cs" />
     <Compile Include="CRUD\Delete\Properties\SectionProperties.cs" />
     <Compile Include="CRUD\Delete\Properties\SurfaceProperties.cs" />
+    <Compile Include="CRUD\Read\Results\BarResults.cs" />
+    <Compile Include="CRUD\Read\Results\MeshResults.cs" />
+    <Compile Include="CRUD\Read\Results\NodeResults.cs" />
+    <Compile Include="CRUD\Read\Results\ReadResults.cs" />
     <Compile Include="PrivateHelpers\GetGroupAssignments.cs" />
     <Compile Include="PrivateHelpers\GetMaxID.cs" />
     <Compile Include="PrivateHelpers\CreateGroups.cs" />
@@ -192,6 +204,9 @@
       <Name>MidasCivil_Engine</Name>
       <Private>False</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MidasCivil_Adapter/Type/NextFreeId.cs
+++ b/MidasCivil_Adapter/Type/NextFreeId.cs
@@ -86,7 +86,7 @@ namespace BH.Adapter.MidasCivil
 
                     if (ExistsSection(section))
                     {
-                        index = GetMaxID(section) + 1;
+                        index = GetMaxId(section) + 1;
                     }
                     else
                     {
@@ -101,7 +101,7 @@ namespace BH.Adapter.MidasCivil
 
                     if (ExistsSection(section))
                     {
-                        index = GetMaxID(section) + 1;
+                        index = GetMaxId(section) + 1;
                     }
                     else
                     {
@@ -116,7 +116,7 @@ namespace BH.Adapter.MidasCivil
                     if (ExistsSection(section))
                     {
 
-                        index = GetMaxID(section) +1;
+                        index = GetMaxId(section) +1;
                     }
                     else
                     {
@@ -130,7 +130,7 @@ namespace BH.Adapter.MidasCivil
 
                     if (ExistsSection(section))
                     {
-                        index = GetMaxID(section) + 1;
+                        index = GetMaxId(section) + 1;
                     }
                     else
                     {
@@ -144,7 +144,7 @@ namespace BH.Adapter.MidasCivil
 
                     if (ExistsSection(section))
                     {
-                        index = GetMaxID(section) + 1;
+                        index = GetMaxId(section) + 1;
                     }
                     else
                     {

--- a/MidasCivil_Adapter/packages.config
+++ b/MidasCivil_Adapter/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Office.Interop.Excel" version="15.0.4795.1000" targetFramework="net452" />
+</packages>

--- a/MidasCivil_Engine/Convert/ToBHoM/Results/ToNodeDisplacement.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Results/ToNodeDisplacement.cs
@@ -20,43 +20,31 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Results;
 using System.Linq;
+using System.Collections.Generic;
 
-namespace BH.Adapter.MidasCivil
+namespace BH.Engine.MidasCivil
 {
-    public partial class MidasCivilAdapter
+    public static partial class Convert
     {
-        private int GetMaxId(string section)
+        public static NodeDisplacement ToNodeDisplacement(this List<string> delimitted)
         {
-            int maxID = 0;
-            
-            List<int> allID = new List<int>();
-            List<string> text = GetSectionText(section);
-            List<List<string>> delimitted = new List<List<string>>();
-            text.ForEach(x =>  delimitted.Add(x.Split(',').ToList()));
-
-            if (!(text.Count() == 0))
+            NodeDisplacement nodeDisplacement = new NodeDisplacement()
             {
-                foreach (List<string> line in delimitted)
-                {
-                    if (Int32.TryParse(line[0],out maxID))
-                    {
-                        allID.Add(maxID);
-                    }
-                }
-                allID.Sort();
-                allID.Reverse();
-                maxID = allID[0];
-            }
-            else
-            {
-                maxID = 1;
-            }
-
-            return maxID;
+                ObjectId = System.Convert.ToInt32(delimitted[2]),
+                ResultCase = delimitted[3],
+                UX = System.Convert.ToDouble(delimitted[7]),
+                UY = System.Convert.ToDouble(delimitted[8]),
+                UZ = System.Convert.ToDouble(delimitted[9]),
+                RX = System.Convert.ToDouble(delimitted[10]),
+                RY = System.Convert.ToDouble(delimitted[11]),
+                RZ = System.Convert.ToDouble(delimitted[12])
+            };
+            return nodeDisplacement;
         }
 
     }
 }
+

--- a/MidasCivil_Engine/Convert/ToBHoM/Results/ToNodeReaction.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Results/ToNodeReaction.cs
@@ -20,43 +20,31 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Results;
 using System.Linq;
+using System.Collections.Generic;
 
-namespace BH.Adapter.MidasCivil
+namespace BH.Engine.MidasCivil
 {
-    public partial class MidasCivilAdapter
+    public static partial class Convert
     {
-        private int GetMaxId(string section)
+        public static NodeReaction ToNodeReaction(this List<string> delimitted)
         {
-            int maxID = 0;
-            
-            List<int> allID = new List<int>();
-            List<string> text = GetSectionText(section);
-            List<List<string>> delimitted = new List<List<string>>();
-            text.ForEach(x =>  delimitted.Add(x.Split(',').ToList()));
-
-            if (!(text.Count() == 0))
+            NodeReaction nodeReaction = new NodeReaction()
             {
-                foreach (List<string> line in delimitted)
-                {
-                    if (Int32.TryParse(line[0],out maxID))
-                    {
-                        allID.Add(maxID);
-                    }
-                }
-                allID.Sort();
-                allID.Reverse();
-                maxID = allID[0];
-            }
-            else
-            {
-                maxID = 1;
-            }
-
-            return maxID;
+                ObjectId = System.Convert.ToInt32(delimitted[2]),
+                ResultCase = delimitted[3],
+                FX = System.Convert.ToDouble(delimitted[7]),
+                FY = System.Convert.ToDouble(delimitted[8]),
+                FZ = System.Convert.ToDouble(delimitted[9]),
+                MX = System.Convert.ToDouble(delimitted[10]),
+                MY = System.Convert.ToDouble(delimitted[11]),
+                MZ = System.Convert.ToDouble(delimitted[12])
+            };
+            return nodeReaction;
         }
 
     }
 }
+

--- a/MidasCivil_Engine/MidasCivil_Engine.csproj
+++ b/MidasCivil_Engine/MidasCivil_Engine.csproj
@@ -65,6 +65,11 @@
       <HintPath>..\..\BHoM_Engine\Build\Library_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.Office.Interop.Excel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Physical_oM, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Physical_oM.dll</HintPath>
@@ -100,12 +105,14 @@
     <Compile Include="Convert\ToBHoM\Elements\ToPanel.cs" />
     <Compile Include="Convert\ToBHoM\Loads\ToLoadNature.cs" />
     <Compile Include="Convert\ToBHoM\Properties\ToConcreteSection.cs" />
+    <Compile Include="Convert\ToBHoM\Results\ToNodeDisplacement.cs" />
     <Compile Include="Convert\ToMidasCivil\Elements\FromFEMesh.cs" />
     <Compile Include="Convert\ToMidasCivil\Loads\FromLoadAxis.cs" />
     <Compile Include="Convert\ToMidasCivil\Loads\FromLoadProjection.cs" />
     <Compile Include="Convert\ToMidasCivil\Loads\FromVector.cs" />
     <Compile Include="Convert\ToMidasCivil\Loads\FromVectorDirection.cs" />
     <Compile Include="Convert\ToMidasCivil\Properties\FromDOFType.cs" />
+    <Compile Include="Convert\ToBHoM\Results\ToNodeReaction.cs" />
     <Compile Include="Objects\ArrayComparer.cs" />
     <Compile Include="Objects\BarMidPointComparer.cs" />
     <Compile Include="Objects\MeshCentreComparer.cs" />
@@ -169,7 +176,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="External\" />
     <Folder Include="Modify\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #173 
Closes #188 

<!-- Add short description of what has been fixed -->
MidasCivil `NodeReaction `results (as an Excel file) can be read
MidasCivil `NodeDisplacement`results (as an Excel file) can be read

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/MidasCivil_Toolkit/MidasCivil_Toolkit-%23173?csf=1&e=q2tImG


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
@StephennipBH when reviewing can you follow this workflow please:
1. Delete any existing .csv or .xls files in the folder
2. Remove any existing text files
3. Export the .mct file from the model 
4. Run the adapter
5. Export Global NodeReaction and NodeDisplacement as an .xls file from MidasCivil (sort by Node then Load)
6. Run the test script for NodeReaction and NodeDisplacement

**Note: When you are checking the results, sort by Node and Load for easy comparison between Result objects and results in MidasCivil**

I have had to close #185 because it could not be rebased due to merge conflicts.