### PR TITLE
Records an error if the excel file it is searching for doesn't exist

### DIFF
--- a/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -196,28 +196,35 @@ namespace BH.Adapter.MidasCivil
 
         private static string ExcelToCsv(string path)
         {
-            string csvPath = GetCSVFile(path);
-            if (!(File.Exists(csvPath)))
+            string csvPath = GetCSVFile(path); ;
+            if (!(File.Exists(path)))
             {
-                Application excel = new Application();
-                Workbook xlsFile = excel.Workbooks.Open(path);
-                Worksheet sheet = (Microsoft.Office.Interop.Excel.Worksheet)xlsFile.Sheets[1];
+                Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit detects no Excel file, make sure you have exported the results from Midas.");
+            }
+            else
+            {
+                if (!(File.Exists(csvPath)))
+                {
+                    Application excel = new Application();
+                    Workbook xlsFile = excel.Workbooks.Open(path);
+                    Worksheet sheet = (Microsoft.Office.Interop.Excel.Worksheet)xlsFile.Sheets[1];
 
-                sheet.SaveAs(
-                    csvPath,
-                    Microsoft.Office.Interop.Excel.XlFileFormat.xlCSV,
-                    Type.Missing,
-                    Type.Missing,
-                    Type.Missing,
-                    Type.Missing,
-                    Microsoft.Office.Interop.Excel.XlSaveAsAccessMode.xlShared,
-                    Type.Missing,
-                    Type.Missing,
-                    Type.Missing
-                );
+                    sheet.SaveAs(
+                        csvPath,
+                        Microsoft.Office.Interop.Excel.XlFileFormat.xlCSV,
+                        Type.Missing,
+                        Type.Missing,
+                        Type.Missing,
+                        Type.Missing,
+                        Microsoft.Office.Interop.Excel.XlSaveAsAccessMode.xlShared,
+                        Type.Missing,
+                        Type.Missing,
+                        Type.Missing
+                    );
 
-                xlsFile.Close();
+                    xlsFile.Close();
 
+                }
             }
 
             return csvPath;

--- a/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -199,7 +199,8 @@ namespace BH.Adapter.MidasCivil
             string csvPath = GetCSVFile(path); ;
             if (!(File.Exists(path)))
             {
-                Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit detects no Excel file, make sure you have exported the results from Midas.");
+                Engine.Reflection.Compute.RecordError("No Excel file detected, please make sure you have exported the results from MidasCivil.");
+                return null;
             }
             else
             {


### PR DESCRIPTION
This will fix the problem for now, recommend that a more effective solution would be to also filter by file type to make sure that it is an excel file type being inserted into the function.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #196 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/ElUYnAEfM75CmIYz7SvR_nIBQVzFj7681FMOmP2XOYlmHQ?e=acWWof

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->