### PR TITLE
Read SectionProperty and Material when reading a Bar

### DIFF
--- a/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
@@ -65,36 +65,45 @@ namespace BH.Adapter.MidasCivil
 
             Dictionary<string, List<int>> barReleaseAssignments = GetBarReleaseAssignments("FRAME-RLS", "barRelease");
 
-            List<string> materialSectionCombos = barText.Select(x => x.Split(',').ToList()[2].Trim()+","+x.Split(',').ToList()[3].Trim()).Distinct().ToList();
+            List<List<string>> materialSectionCombos = barText.Select(x => x.Split(',').ToList()[2].Trim()+","+x.Split(',').ToList()[3].Trim())
+                .Distinct()
+                .Select(x=>x.Split(',').ToList())
+                .ToList();
 
             IMaterialFragment material;
             ISectionProperty section;
             Dictionary<string, ISectionProperty> materialSections = new Dictionary<string, ISectionProperty>();
 
-            foreach(string materialSection in materialSectionCombos)
+            foreach(List<string> materialSection in materialSectionCombos)
             {
-                int materialId = System.Convert.ToInt32(barText[2].Trim());
-                int sectionPropertyId = System.Convert.ToInt32(barText[3].Trim());
+                int materialId = System.Convert.ToInt32(materialSection[0].Trim());
+                int sectionPropertyId = System.Convert.ToInt32(materialSection[1].Trim());
 
                 bhomMaterials.TryGetValue(materialId.ToString(), out material);
                 bhomSectionProperties.TryGetValue(sectionPropertyId.ToString(), out section);
 
+                GenericSection genericSection = (GenericSection)section;
+
                 switch (material.GetType().ToString().Split('.').Last())
                 {
                     case "Concrete":
-                        ConcreteSection concreteSection = (ConcreteSection)section;
+                        ConcreteSection concreteSection = Engine.Structure.Create.ConcreteSectionFromProfile(genericSection.SectionProfile, (Concrete)material);
+                        concreteSection.Name = genericSection.Name;
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), concreteSection);
                         break;
                     case "Steel":
-                        SteelSection steelSection = (SteelSection)section;
+                        SteelSection steelSection = Engine.Structure.Create.SteelSectionFromProfile(genericSection.SectionProfile, (Steel)material);
+                        steelSection.Name = genericSection.Name;
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), steelSection);
                         break;
                     case "Aluminium":
-                        AluminiumSection aluminiumSection = (AluminiumSection)section;
+                        AluminiumSection aluminiumSection = Engine.Structure.Create.AluminiumSectionFromProfile(genericSection.SectionProfile, (Aluminium)material);
+                        aluminiumSection.Name = genericSection.Name;
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), aluminiumSection);
                         break;
                     case "Timber":
-                        TimberSection timberSection = (TimberSection)section;
+                        TimberSection timberSection = Engine.Structure.Create.TimberSectionFromProfile(genericSection.SectionProfile, (Timber)material);
+                        timberSection.Name = genericSection.Name;
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
                         break;
                     default:

--- a/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
@@ -65,16 +65,16 @@ namespace BH.Adapter.MidasCivil
 
             Dictionary<string, List<int>> barReleaseAssignments = GetBarReleaseAssignments("FRAME-RLS", "barRelease");
 
-            List<List<string>> materialSectionCombos = barText.Select(x => x.Split(',').ToList()[2].Trim()+","+x.Split(',').ToList()[3].Trim())
+            List<List<string>> materialSectionCombos = barText.Select(x => x.Split(',').ToList()[2].Trim() + "," + x.Split(',').ToList()[3].Trim())
                 .Distinct()
-                .Select(x=>x.Split(',').ToList())
+                .Select(x => x.Split(',').ToList())
                 .ToList();
 
             IMaterialFragment material;
             ISectionProperty section;
             Dictionary<string, ISectionProperty> materialSections = new Dictionary<string, ISectionProperty>();
 
-            foreach(List<string> materialSection in materialSectionCombos)
+            foreach (List<string> materialSection in materialSectionCombos)
             {
                 int materialId = System.Convert.ToInt32(materialSection[0].Trim());
                 int sectionPropertyId = System.Convert.ToInt32(materialSection[1].Trim());

--- a/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
@@ -65,9 +65,47 @@ namespace BH.Adapter.MidasCivil
 
             Dictionary<string, List<int>> barReleaseAssignments = GetBarReleaseAssignments("FRAME-RLS", "barRelease");
 
+            List<string> materialSectionCombos = barText.Select(x => x.Split(',').ToList()[2].Trim()+","+x.Split(',').ToList()[3].Trim()).Distinct().ToList();
+
+            IMaterialFragment material;
+            ISectionProperty section;
+            Dictionary<string, ISectionProperty> materialSections = new Dictionary<string, ISectionProperty>();
+
+            foreach(string materialSection in materialSectionCombos)
+            {
+                int materialId = System.Convert.ToInt32(barText[2].Trim());
+                int sectionPropertyId = System.Convert.ToInt32(barText[3].Trim());
+
+                bhomMaterials.TryGetValue(materialId.ToString(), out material);
+                bhomSectionProperties.TryGetValue(sectionPropertyId.ToString(), out section);
+
+                switch (material.GetType().ToString().Split('.').Last())
+                {
+                    case "Concrete":
+                        ConcreteSection concreteSection = (ConcreteSection)section;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), concreteSection);
+                        break;
+                    case "Steel":
+                        SteelSection steelSection = (SteelSection)section;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), steelSection);
+                        break;
+                    case "Aluminium":
+                        AluminiumSection aluminiumSection = (AluminiumSection)section;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), aluminiumSection);
+                        break;
+                    case "Timber":
+                        TimberSection timberSection = (TimberSection)section;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
+                        break;
+                    default:
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), section);
+                        break;
+                }
+            }
+
             foreach (string bar in barText)
             {
-                Bar bhomBar = Engine.MidasCivil.Convert.ToBar(bar, bhomNodes, bhomSectionProperties,bhomMaterials, bhomBarReleases, barReleaseAssignments);
+                Bar bhomBar = Engine.MidasCivil.Convert.ToBar(bar, bhomNodes, materialSections, bhomBarReleases, barReleaseAssignments);
                 int bhomID = System.Convert.ToInt32(bhomBar.CustomData[AdapterIdName]);
                 bhomBar.Tags = GetGroupAssignments(elementGroups, bhomID);
                 bhomBars.Add(bhomBar);

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -165,6 +165,7 @@
     <Compile Include="PrivateHelpers\GetSectionText.cs" />
     <Compile Include="CRUD\Create\Create.cs" />
     <Compile Include="CRUD\Delete\Delete.cs" />
+    <Compile Include="PrivateHelpers\SectionMaterialCombinations.cs" />
     <Compile Include="Type\NextFreeId.cs" />
     <Compile Include="PrivateHelpers\GetPropertyAssignments.cs" />
     <Compile Include="PrivateHelpers\CompareGroup.cs" />

--- a/MidasCivil_Adapter/PrivateHelpers/SectionMaterialCombinations.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/SectionMaterialCombinations.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Structure.MaterialFragments;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+    {
+        private static Dictionary<string, ISectionProperty> SectionMaterialCombinations(
+            List<List<string>> combinations, Dictionary<string, IMaterialFragment> materials,
+            Dictionary<string, ISectionProperty> sectionProperties)
+        {
+            IMaterialFragment material;
+            ISectionProperty section;
+            Dictionary<string, ISectionProperty> materialSections = new Dictionary<string, ISectionProperty>();
+
+            foreach (List<string> materialSection in combinations)
+            {
+                int materialId = System.Convert.ToInt32(materialSection[0].Trim());
+                int sectionPropertyId = System.Convert.ToInt32(materialSection[1].Trim());
+
+                materials.TryGetValue(materialId.ToString(), out material);
+                sectionProperties.TryGetValue(sectionPropertyId.ToString(), out section);
+
+                GenericSection genericSection = (GenericSection)section;
+
+                switch (material.GetType().ToString().Split('.').Last())
+                {
+                    case "Concrete":
+                        ConcreteSection concreteSection = Engine.Structure.Create.ConcreteSectionFromProfile(genericSection.SectionProfile, (Concrete)material);
+                        concreteSection.Name = genericSection.Name;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), concreteSection);
+                        break;
+                    case "Steel":
+                        SteelSection steelSection = Engine.Structure.Create.SteelSectionFromProfile(genericSection.SectionProfile, (Steel)material);
+                        steelSection.Name = genericSection.Name;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), steelSection);
+                        break;
+                    case "Aluminium":
+                        AluminiumSection aluminiumSection = Engine.Structure.Create.AluminiumSectionFromProfile(genericSection.SectionProfile, (Aluminium)material);
+                        aluminiumSection.Name = genericSection.Name;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), aluminiumSection);
+                        break;
+                    case "Timber":
+                        TimberSection timberSection = Engine.Structure.Create.TimberSectionFromProfile(genericSection.SectionProfile, (Timber)material);
+                        timberSection.Name = genericSection.Name;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
+                        break;
+                    default:
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), section);
+                        break;
+                }
+            }
+
+            return materialSections;
+        }
+
+    }
+}

--- a/MidasCivil_Adapter/PrivateHelpers/SectionMaterialCombinations.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/SectionMaterialCombinations.cs
@@ -70,7 +70,8 @@ namespace BH.Adapter.MidasCivil
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
                         break;
                     default:
-                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), section);
+                        genericSection.Material = material;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericSection);
                         break;
                 }
             }

--- a/MidasCivil_Adapter/PrivateHelpers/SectionMaterialCombinations.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/SectionMaterialCombinations.cs
@@ -69,9 +69,20 @@ namespace BH.Adapter.MidasCivil
                         timberSection.Name = genericSection.Name;
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
                         break;
+                    case "GenericIsotropicMaterial":
+                        GenericSection genericIsoptropicSection = 
+                            Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericIsotropicMaterial)material);
+                        genericIsoptropicSection.Name = genericSection.Name;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericIsoptropicSection);
+                        break;
+                    case "GenericOrthotropicMaterial":
+                        GenericSection genericOrthotropicSection =
+                            Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericOrthotropicMaterial)material);
+                        genericOrthotropicSection.Name = genericSection.Name;
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericOrthotropicSection);
+                        break;
                     default:
-                        genericSection.Material = material;
-                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericSection);
+                        Engine.Reflection.Compute.RecordError(material.GetType().ToString().Split('.').Last() + "not recognised");
                         break;
                 }
             }

--- a/MidasCivil_Engine/Convert/ToBHoM/Elements/ToBar.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Elements/ToBar.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.MidasCivil
     public static partial class Convert
     {
         public static Bar ToBar(this string bar, Dictionary<string, Node> bhomNodes,
-            Dictionary<string, ISectionProperty> bhomSectionProperties, Dictionary<string, IMaterialFragment> bhomMaterials,
+            Dictionary<string, ISectionProperty> bhomSectionProperties,
             Dictionary<string, BarRelease> barReleases, Dictionary<string, List<int>> barReleaseAssignments)
         {
             List<string> delimitted = bar.Split(',').ToList();
@@ -47,19 +47,7 @@ namespace BH.Engine.MidasCivil
 
             if (!(bhomSectionProperties.Count() == 0))
             {
-                bhomSectionProperties.TryGetValue(delimitted[3].Trim(), out sectionProperty);
-                if (!(bhomMaterials.Count() == 0))
-                {
-                    IMaterialFragment bhommMaterial;
-                    bhomMaterials.TryGetValue(delimitted[2].Trim(), out bhommMaterial);
-
-                    if (bhommMaterial.GetType().ToString().Split('.').Last() == "Concrete")
-                    {
-                        sectionProperty = ToConcreteSection((SteelSection)sectionProperty);
-                    }
-
-                    sectionProperty.Material = bhommMaterial;
-                }
+                bhomSectionProperties.TryGetValue(delimitted[2].Trim()+","+delimitted[3].Trim(), out sectionProperty);
             }
 
             switch (delimitted[1].Trim())

--- a/MidasCivil_Engine/Convert/ToBHoM/Properties/ToMaterials.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Properties/ToMaterials.cs
@@ -54,7 +54,6 @@ namespace BH.Engine.MidasCivil
                 {
                     case "USER":
                         if ((delimited[9].Trim()) == "2")
-
                         {
                             bhomMaterial = new GenericIsotropicMaterial()
                             {
@@ -69,6 +68,7 @@ namespace BH.Engine.MidasCivil
                             Engine.Reflection.Compute.RecordWarning("Material " + name + " is a USER defined material and will default to a Generic Isotropic material");
                         }
                         else if ((delimited[9].Trim()) == "3")
+                        {
                             bhomMaterial = new GenericOrthotropicMaterial()
                             {
                                 Name = name,
@@ -81,7 +81,8 @@ namespace BH.Engine.MidasCivil
                                 DampingRatio = double.Parse(delimited[8].Trim())
 
                             };
-                        Engine.Reflection.Compute.RecordWarning("Material " + name + " is a USER defined material and will default to a Generic Orthotropic material");
+                            Engine.Reflection.Compute.RecordWarning("Material " + name + " is a USER defined material and will default to a Generic Orthotropic material");
+                        }
                         break;
                     case "STEEL":
                         if (delimited.Count() == 15)
@@ -117,8 +118,7 @@ namespace BH.Engine.MidasCivil
                         }
                         else
                         {
-                            Reflection.Compute.RecordWarning("Material not found in BHoM Library: C30/37 Concrete properties assumed");
-                            bhomMaterial = (IMaterialFragment)BH.Engine.Library.Query.Match("Materials", "C30/37");
+                            Reflection.Compute.RecordWarning("Material not found in BHoM Library.");
                         }
                         break;
                     case "SRC":

--- a/MidasCivil_Engine/Convert/ToBHoM/Properties/ToSectionProperty.cs
+++ b/MidasCivil_Engine/Convert/ToBHoM/Properties/ToSectionProperty.cs
@@ -145,7 +145,7 @@ namespace BH.Engine.MidasCivil
 
             bhomProfile = Engine.Structure.Compute.Integrate(bhomProfile, oM.Geometry.Tolerance.MicroDistance).Item1;
 
-            SteelSection bhomSection = new SteelSection(
+            GenericSection bhomSection = new GenericSection(
                 bhomProfile, area, rgy, rgz, j, iy, iz, iw,
                 wely, welz, wply, wplz, centreZ, centreY, zt, zb, yt, yb, asy, asz);
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #198 

<!-- Add short description of what has been fixed -->
- `SectionProperty` now read as a `GenericSection `
- Casting of `ISectionProperty `to `SteelSection`, `ConcreteSection `etc. is done at Adapter level
- Unique list of `SectionProperty`/`Material `combinations generated and fed in to Convert.ToBar(..)

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/ElOqrdbYH0dDsulwV4dm-XIBmvigR3XIam-P1we2UFDgTg?e=5STKqN

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `SectionProperty` now read as a `GenericSection `
- Casting of `ISectionProperty `to `SteelSection`, `ConcreteSection `etc. is done at Adapter level
- Unique list of `SectionProperty`/`Material `combinations generated and fed in to Convert.ToBar(..)
