### PR TITLE
Changing method from private to public

### DIFF
--- a/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
         /**** Private method - Read override            ****/
         /***************************************************/
 
-        private IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
+        public IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
         {
             List<IResult> results;
             List<int> objectIds = GetObjectIDs(request);

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
         /**** Private method - Read override            ****/
         /***************************************************/
 
-        private IEnumerable<IResult> ReadResults(MeshResultRequest request, ActionConfig actionConfig)
+        public IEnumerable<IResult> ReadResults(MeshResultRequest request, ActionConfig actionConfig)
         {
             List<IResult> results;
             List<int> objectIds = GetObjectIDs(request);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #215 

<!-- Add short description of what has been fixed -->
Changed method from `private` to `public` to fix a bug in pulling results from Midas.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FMidasCivil%5FToolkit%2FMidasCivil%5FToolkit%2D%23190

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional comments
<!-- As required -->
The workflow for reviewing pulling results @peterjamesnugent :
- Delete any existing .csv or .xls files in the folder
- Remove any existing text files
- Export the .mct file from the model
- Run the adapter
- Export Global `Beam Force` , `Beam Stress` and `Plate Force(UL_Local)` as an .xls file from MidasCivil
- Run the test script for `BarForce` , `BarStress` and `MeshForce`

**Note: When you are checking the results, sort by element number for easy comparison between Result objects and results in MidasCivil. Please pull bar results from the `PullBarResullts` file and pull mesh results from the `PullMeshForceResults` file.**