### PR TITLE
Added functionality to read remaining MeshResults

### DIFF
--- a/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
         /**** Private method - Read override            ****/
         /***************************************************/
 
-        private IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
+        public IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
         {
             List<IResult> results;
             List<int> objectIds = GetObjectIDs(request);

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -103,10 +103,23 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
             List<MeshStress> meshStresses = new List<MeshStress>();
-            for (int i = 10; i < meshStressText.Count; i++)
+
+            List<string> meshStress = meshStressText[10].Split(',').ToList();
+            List<string> InitialmeshStress = meshStress;
+            meshStresses.Add(Convert.ToMeshStress(meshStress));
+
+            for (int i = 11; i < meshStressText.Count; i++)
             {
-                List<string> meshStress = meshStressText[i].Split(',').ToList();
+                meshStress = meshStressText[i].Split(',').ToList();
+                for (int j = 0; j < meshStress.Count; j++)
+                {
+                    if (meshStress[j] == "")
+                    {
+                        meshStress[j] = InitialmeshStress[j];
+                    }
+                }
                 meshStresses.Add(Convert.ToMeshStress(meshStress));
+
             }
 
             return meshStresses;
@@ -114,7 +127,31 @@ namespace BH.Adapter.MidasCivil
 
         private IEnumerable<IResult> ExtractMeshVonMises(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
         {
-            return null;
+            /***************************************************/
+            string filePath = directory + "\\Plate Stress(L).xls";
+            string csvPath = ExcelToCsv(filePath);
+            List<string> meshVonMisesText = File.ReadAllLines(csvPath).ToList();
+            List<MeshVonMises> meshVonMiseses = new List<MeshVonMises>();
+
+            List<string> meshVonMises = meshVonMisesText[10].Split(',').ToList();
+            List<string> InitialmeshVonMises = meshVonMises;
+            meshVonMiseses.Add(Convert.ToMeshVonMises(meshVonMises));
+
+            for (int i = 11; i < meshVonMisesText.Count; i++)
+            {
+                meshVonMises = meshVonMisesText[i].Split(',').ToList();
+                for (int j = 0; j < meshVonMises.Count; j++)
+                {
+                    if (meshVonMises[j] == "")
+                    {
+                        meshVonMises[j] = InitialmeshVonMises[j];
+                    }
+                }
+
+                meshVonMiseses.Add(Convert.ToMeshVonMises(meshVonMises));
+            }
+
+            return meshVonMiseses;
         }
 
         /***************************************************/

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -102,11 +102,11 @@ namespace BH.Adapter.MidasCivil
             string filePath = directory + "\\Plate Stress(L).xls";
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
-            List<MeshForce> meshStresses = new List<MeshForce>();
+            List<MeshStress> meshStresses = new List<MeshStress>();
             for (int i = 16; i < meshStressText.Count; i++)
             {
                 List<string> meshStress = meshStressText[i].Split(',').ToList();
-                meshStresses.Add(Convert.ToMeshForce(meshStress));
+                meshStresses.Add(Convert.ToMeshStress(meshStress));
             }
 
             return meshStresses;

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -98,7 +98,18 @@ namespace BH.Adapter.MidasCivil
 
         private IEnumerable<IResult> ExtractMeshStress(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
         {
-            return null;
+            /***************************************************/
+            string filePath = directory + "\\Plate Stress(L).xls";
+            string csvPath = ExcelToCsv(filePath);
+            List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
+            List<MeshForce> meshStresses = new List<MeshForce>();
+            for (int i = 16; i < meshStressText.Count; i++)
+            {
+                List<string> meshStress = meshStressText[i].Split(',').ToList();
+                meshStresses.Add(Convert.ToMeshForce(meshStress));
+            }
+
+            return meshStresses;
         }
 
         private IEnumerable<IResult> ExtractMeshVonMises(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -103,19 +103,19 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
             List<MeshStress> meshStresses = new List<MeshStress>();
-            List<string> InitialmeshStress = new List<string>();
+            List<string> initialmeshStress = new List<string>();
 
             for (int i = 10; i < meshStressText.Count; i++)
             {
                 List<string> meshStress = meshStressText[i].Split(',').ToList();
                     if (meshStress[2] == "")
                     {
-                        meshStress[2] = InitialmeshStress[2];
-                        meshStress[3] = InitialmeshStress[3];
-                        meshStress[7] = InitialmeshStress[7];
+                        meshStress[2] = initialmeshStress[2];
+                        meshStress[3] = initialmeshStress[3];
+                        meshStress[7] = initialmeshStress[7];
                     }
                 meshStresses.Add(Convert.ToMeshStress(meshStress));
-                InitialmeshStress = meshStressText[i].Split(',').ToList();
+                initialmeshStress = meshStressText[i].Split(',').ToList();
             }
 
             return meshStresses;
@@ -130,19 +130,19 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshVonMisesText = File.ReadAllLines(csvPath).ToList();
             List<MeshVonMises> meshVonMiseses = new List<MeshVonMises>();
-            List<string> InitialmeshVonMises = new List<string>();
+            List<string> initialmeshVonMises = new List<string>();
 
             for (int i = 10; i < meshVonMisesText.Count; i++)
             {
                List<string> meshVonMises = meshVonMisesText[i].Split(',').ToList();
                     if (meshVonMises[2] == "")
                     {
-                        meshVonMises[2] = InitialmeshVonMises[2];
-                        meshVonMises[7] = InitialmeshVonMises[7];
-                        meshVonMises[3] = InitialmeshVonMises[3];
+                        meshVonMises[2] = initialmeshVonMises[2];
+                        meshVonMises[7] = initialmeshVonMises[7];
+                        meshVonMises[3] = initialmeshVonMises[3];
                     }
                 meshVonMiseses.Add(Convert.ToMeshVonMises(meshVonMises));
-                InitialmeshVonMises = meshVonMisesText[i].Split(',').ToList();
+                initialmeshVonMises = meshVonMisesText[i].Split(',').ToList();
             }
 
             return meshVonMiseses;

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -103,31 +103,25 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
             List<MeshStress> meshStresses = new List<MeshStress>();
+            List<string> initialmeshStress = new List<string>();
 
-            List<string> meshStress = meshStressText[10].Split(',').ToList();
-            List<string> InitialmeshStress = meshStress;
-            meshStresses.Add(Convert.ToMeshStress(meshStress));
-
-            for (int i = 11; i < meshStressText.Count; i++)
+            for (int i = 10; i < meshStressText.Count; i++)
             {
-                meshStress = meshStressText[i].Split(',').ToList();
-                InitialmeshStress = meshStressText[i - 1].Split(',').ToList();
-                for (int j = 0; j < meshStress.Count; j++)
+                List<string> meshStress = meshStressText[i].Split(',').ToList();
+                if (meshStress[2] == "")
                 {
-                    if (meshStress[2] == "")
-                    {
-                        meshStress[2] = InitialmeshStress[2];
-                        meshStress[3] = InitialmeshStress[3];
-                        meshStress[7] = InitialmeshStress[7];
-                    }
+                    meshStress[2] = initialmeshStress[2];
+                    meshStress[3] = initialmeshStress[3];
+                    meshStress[7] = initialmeshStress[7];
                 }
-
                 meshStresses.Add(Convert.ToMeshStress(meshStress));
-
+                initialmeshStress = meshStressText[i].Split(',').ToList();
             }
 
             return meshStresses;
         }
+        
+        /***************************************************/
 
         private IEnumerable<IResult> ExtractMeshVonMises(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
         {
@@ -136,26 +130,19 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshVonMisesText = File.ReadAllLines(csvPath).ToList();
             List<MeshVonMises> meshVonMiseses = new List<MeshVonMises>();
+            List<string> InitialmeshVonMises = new List<string>();
 
-            List<string> meshVonMises = meshVonMisesText[10].Split(',').ToList();
-            List<string> InitialmeshVonMises = meshVonMises;
-            meshVonMiseses.Add(Convert.ToMeshVonMises(meshVonMises));
-
-            for (int i = 11; i < meshVonMisesText.Count; i++)
+            for (int i = 10; i < meshVonMisesText.Count; i++)
             {
-                meshVonMises = meshVonMisesText[i].Split(',').ToList();
-                InitialmeshVonMises = meshVonMisesText[i - 1].Split(',').ToList();
-                for (int j = 0; j < meshVonMises.Count; j++)
-                {
+               List<string> meshVonMises = meshVonMisesText[i].Split(',').ToList();
                     if (meshVonMises[2] == "")
                     {
                         meshVonMises[2] = InitialmeshVonMises[2];
                         meshVonMises[7] = InitialmeshVonMises[7];
                         meshVonMises[3] = InitialmeshVonMises[3];
                     }
-                }
-
                 meshVonMiseses.Add(Convert.ToMeshVonMises(meshVonMises));
+                InitialmeshVonMises = meshVonMisesText[i].Split(',').ToList();
             }
 
             return meshVonMiseses;

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -111,11 +111,14 @@ namespace BH.Adapter.MidasCivil
             for (int i = 11; i < meshStressText.Count; i++)
             {
                 meshStress = meshStressText[i].Split(',').ToList();
+                InitialmeshStress= meshStressText[i-1].Split(',').ToList();
                 for (int j = 0; j < meshStress.Count; j++)
                 {
-                    if (meshStress[j] == "")
+                    if (meshStress[2] == "")
                     {
-                        meshStress[j] = InitialmeshStress[j];
+                        meshStress[2] = InitialmeshStress[2];
+                        meshStress[3] = InitialmeshStress[3];
+                        meshStress[7] = InitialmeshStress[7];
                     }
                 }
                 meshStresses.Add(Convert.ToMeshStress(meshStress));
@@ -132,19 +135,22 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshVonMisesText = File.ReadAllLines(csvPath).ToList();
             List<MeshVonMises> meshVonMiseses = new List<MeshVonMises>();
-
+            
             List<string> meshVonMises = meshVonMisesText[10].Split(',').ToList();
-            List<string> InitialmeshVonMises = meshVonMises;
+         List<string> InitialmeshVonMises = meshVonMises;
             meshVonMiseses.Add(Convert.ToMeshVonMises(meshVonMises));
 
             for (int i = 11; i < meshVonMisesText.Count; i++)
             {
                 meshVonMises = meshVonMisesText[i].Split(',').ToList();
+                InitialmeshVonMises = meshVonMisesText[i-1].Split(',').ToList();
                 for (int j = 0; j < meshVonMises.Count; j++)
                 {
-                    if (meshVonMises[j] == "")
+                    if (meshVonMises[2] == "")
                     {
-                        meshVonMises[j] = InitialmeshVonMises[j];
+                        meshVonMises[2] = InitialmeshVonMises[2];
+                        meshVonMises[7] = InitialmeshVonMises[7];
+                        meshVonMises[3] = InitialmeshVonMises[3];
                     }
                 }
 

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -111,7 +111,7 @@ namespace BH.Adapter.MidasCivil
             for (int i = 11; i < meshStressText.Count; i++)
             {
                 meshStress = meshStressText[i].Split(',').ToList();
-                InitialmeshStress= meshStressText[i-1].Split(',').ToList();
+                InitialmeshStress = meshStressText[i - 1].Split(',').ToList();
                 for (int j = 0; j < meshStress.Count; j++)
                 {
                     if (meshStress[2] == "")
@@ -121,6 +121,7 @@ namespace BH.Adapter.MidasCivil
                         meshStress[7] = InitialmeshStress[7];
                     }
                 }
+
                 meshStresses.Add(Convert.ToMeshStress(meshStress));
 
             }
@@ -135,15 +136,15 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshVonMisesText = File.ReadAllLines(csvPath).ToList();
             List<MeshVonMises> meshVonMiseses = new List<MeshVonMises>();
-            
+
             List<string> meshVonMises = meshVonMisesText[10].Split(',').ToList();
-         List<string> InitialmeshVonMises = meshVonMises;
+            List<string> InitialmeshVonMises = meshVonMises;
             meshVonMiseses.Add(Convert.ToMeshVonMises(meshVonMises));
 
             for (int i = 11; i < meshVonMisesText.Count; i++)
             {
                 meshVonMises = meshVonMisesText[i].Split(',').ToList();
-                InitialmeshVonMises = meshVonMisesText[i-1].Split(',').ToList();
+                InitialmeshVonMises = meshVonMisesText[i - 1].Split(',').ToList();
                 for (int j = 0; j < meshVonMises.Count; j++)
                 {
                     if (meshVonMises[2] == "")

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -103,19 +103,19 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
             List<MeshStress> meshStresses = new List<MeshStress>();
-            List<string> initialmeshStress = new List<string>();
+            List<string> InitialmeshStress = new List<string>();
 
             for (int i = 10; i < meshStressText.Count; i++)
             {
                 List<string> meshStress = meshStressText[i].Split(',').ToList();
-                if (meshStress[2] == "")
-                {
-                    meshStress[2] = initialmeshStress[2];
-                    meshStress[3] = initialmeshStress[3];
-                    meshStress[7] = initialmeshStress[7];
-                }
+                    if (meshStress[2] == "")
+                    {
+                        meshStress[2] = InitialmeshStress[2];
+                        meshStress[3] = InitialmeshStress[3];
+                        meshStress[7] = InitialmeshStress[7];
+                    }
                 meshStresses.Add(Convert.ToMeshStress(meshStress));
-                initialmeshStress = meshStressText[i].Split(',').ToList();
+                InitialmeshStress = meshStressText[i].Split(',').ToList();
             }
 
             return meshStresses;

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
         /**** Private method - Read override            ****/
         /***************************************************/
 
-        private IEnumerable<IResult> ReadResults(MeshResultRequest request, ActionConfig actionConfig)
+        public IEnumerable<IResult> ReadResults(MeshResultRequest request, ActionConfig actionConfig)
         {
             List<IResult> results;
             List<int> objectIds = GetObjectIDs(request);
@@ -103,7 +103,7 @@ namespace BH.Adapter.MidasCivil
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
             List<MeshStress> meshStresses = new List<MeshStress>();
-            for (int i = 16; i < meshStressText.Count; i++)
+            for (int i = 10; i < meshStressText.Count; i++)
             {
                 List<string> meshStress = meshStressText[i].Split(',').ToList();
                 meshStresses.Add(Convert.ToMeshStress(meshStress));

--- a/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -34,6 +34,7 @@ using BH.oM.Structure.Requests;
 using Application = Microsoft.Office.Interop.Excel.Application;
 using Workbook = Microsoft.Office.Interop.Excel.Workbook;
 using Worksheet = Microsoft.Office.Interop.Excel.Worksheet;
+using Microsoft.Office.Interop.Excel;
 using System.Linq;
 
 namespace BH.Adapter.MidasCivil
@@ -210,7 +211,15 @@ namespace BH.Adapter.MidasCivil
                     Application excel = new Application();
                     Workbook xlsFile = excel.Workbooks.Open(path);
                     Worksheet sheet = (Microsoft.Office.Interop.Excel.Worksheet)xlsFile.Sheets[1];
-
+                    Range sheetRange = sheet.Range["A1:X999"];
+                        foreach(Range cell in sheetRange)
+                        {
+                            if (cell.MergeCells) { }
+                        Range cellarea = cell.MergeArea;
+                            cellarea.UnMerge();
+                            cellarea.Formula = cell.Formula();
+                        }
+                                   
                     sheet.SaveAs(
                         csvPath,
                         Microsoft.Office.Interop.Excel.XlFileFormat.xlCSV,

--- a/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -211,14 +211,6 @@ namespace BH.Adapter.MidasCivil
                     Application excel = new Application();
                     Workbook xlsFile = excel.Workbooks.Open(path);
                     Worksheet sheet = (Microsoft.Office.Interop.Excel.Worksheet)xlsFile.Sheets[1];
-                    Range sheetRange = sheet.Range["A1:X999"];
-                        foreach(Range cell in sheetRange)
-                        {
-                            if (cell.MergeCells) { }
-                        Range cellarea = cell.MergeArea;
-                            cellarea.UnMerge();
-                            cellarea.Formula = cell.Formula();
-                        }
                                    
                     sheet.SaveAs(
                         csvPath,

--- a/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshStress.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshStress.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Results;
+using System.Linq;
+using System.Collections.Generic;
+using BH.oM.Geometry;
+
+namespace BH.Adapter.MidasCivil
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static MeshStress ToMeshStress(this List<string> delimitted)
+        {
+            MeshStress Meshstress = new MeshStress(System.Convert.ToInt32(delimitted[2]), delimitted[7], 0,
+            delimitted[3], 0, MeshResultLayer.Middle, 0.5, MeshResultSmoothingType.None, null,
+            System.Convert.ToDouble(delimitted[9]), System.Convert.ToDouble(delimitted[10]), 0,
+            System.Convert.ToDouble(delimitted[11]), System.Convert.ToDouble(delimitted[11]), System.Convert.ToDouble(delimitted[12]),
+            System.Convert.ToDouble(delimitted[13]), 0);
+
+            return Meshstress;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshStress.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshStress.cs
@@ -36,8 +36,14 @@ namespace BH.Adapter.MidasCivil
 
         public static MeshStress ToMeshStress(this List<string> delimitted)
         {
+            double LayerPosition = 1;
+
+            if (delimitted[8].Contains("Bot"))
+            {
+                LayerPosition = 0;
+            }
             MeshStress Meshstress = new MeshStress(System.Convert.ToInt32(delimitted[2]), delimitted[7], 0,
-            delimitted[3], 0, MeshResultLayer.Middle, 0.5, MeshResultSmoothingType.None, null,
+            delimitted[3], 0, MeshResultLayer.Middle, LayerPosition, MeshResultSmoothingType.None, null,
             System.Convert.ToDouble(delimitted[9]), System.Convert.ToDouble(delimitted[10]), 0,
             System.Convert.ToDouble(delimitted[11]), System.Convert.ToDouble(delimitted[11]), System.Convert.ToDouble(delimitted[12]),
             System.Convert.ToDouble(delimitted[13]), 0);

--- a/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshStress.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshStress.cs
@@ -37,13 +37,15 @@ namespace BH.Adapter.MidasCivil
         public static MeshStress ToMeshStress(this List<string> delimitted)
         {
             double LayerPosition = 1;
+            MeshResultLayer meshResultLayer = MeshResultLayer.Upper;
 
             if (delimitted[8].Contains("Bot"))
             {
                 LayerPosition = 0;
+                meshResultLayer = MeshResultLayer.Lower;
             }
             MeshStress Meshstress = new MeshStress(System.Convert.ToInt32(delimitted[2]), delimitted[7], 0,
-            delimitted[3], 0, MeshResultLayer.Middle, LayerPosition, MeshResultSmoothingType.None, null,
+            delimitted[3], 0, meshResultLayer, LayerPosition, MeshResultSmoothingType.None, null,
             System.Convert.ToDouble(delimitted[9]), System.Convert.ToDouble(delimitted[10]), 0,
             System.Convert.ToDouble(delimitted[11]), System.Convert.ToDouble(delimitted[11]), System.Convert.ToDouble(delimitted[12]),
             System.Convert.ToDouble(delimitted[13]), 0);

--- a/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshVonMises.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshVonMises.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Results;
+using System.Linq;
+using System.Collections.Generic;
+using BH.oM.Geometry;
+
+namespace BH.Adapter.MidasCivil
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static MeshVonMises ToMeshVonMises(this List<string> delimitted)
+        {
+            double LayerPosition = 1;
+
+            if (delimitted[8].Contains("Bot"))
+            {
+                LayerPosition = 0;
+            }
+            MeshVonMises MeshVonMises = new MeshVonMises(System.Convert.ToInt32(delimitted[2]), delimitted[7], 0,
+            delimitted[3], 0, MeshResultLayer.Middle, LayerPosition, MeshResultSmoothingType.None, null,0,0, System.Convert.ToDouble(delimitted[15])
+            );
+
+            return MeshVonMises;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshVonMises.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Results/ToMeshVonMises.cs
@@ -37,13 +37,15 @@ namespace BH.Adapter.MidasCivil
         public static MeshVonMises ToMeshVonMises(this List<string> delimitted)
         {
             double LayerPosition = 1;
+            MeshResultLayer meshResultLayer = MeshResultLayer.Upper;
 
             if (delimitted[8].Contains("Bot"))
             {
                 LayerPosition = 0;
+                meshResultLayer = MeshResultLayer.Lower;
             }
             MeshVonMises MeshVonMises = new MeshVonMises(System.Convert.ToInt32(delimitted[2]), delimitted[7], 0,
-            delimitted[3], 0, MeshResultLayer.Middle, LayerPosition, MeshResultSmoothingType.None, null,0,0, System.Convert.ToDouble(delimitted[15])
+            delimitted[3], 0, meshResultLayer, LayerPosition, MeshResultSmoothingType.None, null,0,0, System.Convert.ToDouble(delimitted[15])
             );
 
             return MeshVonMises;

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Convert\ToBHoM\Properties\ToProfile.cs" />
     <Compile Include="Convert\ToBHoM\Properties\ToSectionProperty.cs" />
     <Compile Include="Convert\ToBHoM\Properties\ToSurfaceProperty.cs" />
+    <Compile Include="Convert\ToBHoM\Results\ToMeshVonMises.cs" />
     <Compile Include="Convert\ToBHoM\Results\ToMeshStress.cs" />
     <Compile Include="Convert\ToBHoM\Results\ToBarForce.cs" />
     <Compile Include="Convert\ToBHoM\Results\ToBarStress.cs" />

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Convert\ToBHoM\Properties\ToProfile.cs" />
     <Compile Include="Convert\ToBHoM\Properties\ToSectionProperty.cs" />
     <Compile Include="Convert\ToBHoM\Properties\ToSurfaceProperty.cs" />
+    <Compile Include="Convert\ToBHoM\Results\ToMeshStress.cs" />
     <Compile Include="Convert\ToBHoM\Results\ToBarForce.cs" />
     <Compile Include="Convert\ToBHoM\Results\ToBarStress.cs" />
     <Compile Include="Convert\ToBHoM\Results\ToMeshForce.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #214  

<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FMidasCivil%5FToolkit%2FMidasCivil%5FToolkit%2D%23190

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Added functionality to read `MeshStress` results
Added functionality to read `MeshVonMises` results

### Additional comments
<!-- As required -->
@peterjamesnugent  when reviewing can you follow this workflow please:

- Delete any existing .csv or .xls files in the folder
- Remove any existing text files
- Run the adapter
- Export excel result named `Plate Stress(L)` as an .xls file from MidasCivil
- Run the test script for `MeshStress`.
- Change the filter request for `MeshVonMises` and test it.

**Note: When you are checking the results, sort by element number for easy comparison between Result objects and results in MidasCivil. Please pull mesh results from the `PullMeshForceResults` file.**