### PR TITLE
Various bug fixes for reading from MidasCivil

### DIFF
--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarPointLoads.cs
@@ -110,7 +110,7 @@ namespace BH.Adapter.MidasCivil
                             BarPointLoad bhomBarPointLoad = Adapter.Adapters.MidasCivil.Convert.ToBarPointLoad(distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, j);
                             bhomBarPointLoads.Add(bhomBarPointLoad);
 
-                            if (String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[22]))
+                            if (String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))
 
                             {
                                 j = j + 1;

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoad.cs
@@ -104,7 +104,7 @@ namespace BH.Adapter.MidasCivil
                             bhomBarUniformlyDistributedLoads.Add(bhomBarUniformlyDistributedLoad);
 
 
-                            if ((distinctBarLoad.Split(',').ToList()[22].ToString() == " "))
+                            if(String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))
                             {
                                 i = i + 1;
                             }

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
@@ -94,7 +94,7 @@ namespace BH.Adapter.MidasCivil
                             bhomBarVaryingDistributedLoads.Add(bhomBarVaryingDistributedLoad);
 
 
-                            if (String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[22]))
+                            if (String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))
                             {
                                 i = i + 1;
                             }

--- a/MidasCivil_Adapter/CRUD/Read/Loads/GravityLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/GravityLoads.cs
@@ -63,14 +63,11 @@ namespace BH.Adapter.MidasCivil
 
                     foreach (string gravityLoad in gravityLoadText)
                     {
-                        List<string> delimitted = gravityLoad.Split(',').ToList();
-                        delimitted.RemoveAt(0);
-                        gravityLoads.Add(String.Join(",", delimitted));
-                        GravityLoad bhomGravityLoad = Adapter.Adapters.MidasCivil.Convert.ToGravityLoad(
+                        GravityLoad bhomGravityLoad = Adapters.MidasCivil.Convert.ToGravityLoad(
                             objects, gravityLoad, loadcase, loadcaseDictionary, i);
                         bhomGravityLoads.Add(bhomGravityLoad);
 
-                        if (String.IsNullOrWhiteSpace(delimitted[3]))
+                        if (String.IsNullOrWhiteSpace(gravityLoad.Split(',')[3]))
                         {
                             i = i + 1;
                         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -44,19 +44,19 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             Vector direction = new Vector
             {
-                X = double.Parse(delimitted[1].Trim()),
-                Y = double.Parse(delimitted[2].Trim()),
-                Z = double.Parse(delimitted[3].Trim())
+                X = double.Parse(delimitted[0].Trim()),
+                Y = double.Parse(delimitted[1].Trim()),
+                Z = double.Parse(delimitted[2].Trim())
             };
             string name;
 
-            if (string.IsNullOrWhiteSpace(delimitted[4]))
+            if (string.IsNullOrWhiteSpace(delimitted[3]))
             {
                 name = "GL" + count;
             }
             else
             {
-                name = delimitted[4].Trim();
+                name = delimitted[3].Trim();
             }
 
             GravityLoad bhomGravityLoad = BH.Engine.Structure.Create.GravityLoad(bhomLoadcase, direction, objects, name);

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSectionProperty.cs
@@ -74,10 +74,10 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else if (shape == "H")
             {
-                bhomSection = Engine.Structure.Create.GenericSectionFromProfile(Engine.Structure.Create.FabricatedISectionProfile
-                    (System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[16]),
-                    System.Convert.ToDouble(split[15]), System.Convert.ToDouble(split[17]),
-                    System.Convert.ToDouble(split[18]), System.Convert.ToDouble(split[19]), 0), null);
+                bhomSection = Create.GenericSectionFromProfile(Engine.Geometry.Create.FabricatedISectionProfile
+                    (System.Convert.ToDouble(split[14]), System.Convert.ToDouble(split[15]),
+                    System.Convert.ToDouble(split[18]), System.Convert.ToDouble(split[16]),
+                    System.Convert.ToDouble(split[17]), System.Convert.ToDouble(split[19]), 0), null);
 
                 //    8, DBUSER    , USER-ISECTION     , CC, 0, 0, 0, 0, 0, 0, YES, NO, H  , 2, 1, 0.3, 0.03, 0.025, 0.5, 0.02, 0.01, 0.01, 0, 0
             }

--- a/MidasCivil_Adapter/PrivateHelpers/GetSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/GetSectionText.cs
@@ -51,11 +51,6 @@ namespace BH.Adapter.MidasCivil
         {
             List<string> cleanString = new List<string>();
 
-            if (sectionText[0].Contains("SELFWEIGHT"))
-            {
-                cleanString.Add(sectionText[0].Split('*')[1]);
-            }
-
             for (int i = 0; i < sectionText.Count; i++)
             {
                 if (!(sectionText[i].Contains(";")) && !(sectionText[i].Contains("*")) && !(string.IsNullOrEmpty(sectionText[i])))

--- a/MidasCivil_Adapter/PrivateHelpers/GetTags.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/GetTags.cs
@@ -44,7 +44,7 @@ namespace BH.Adapter.MidasCivil
 
                 List<int> itemAssignment = new List<int>();
 
-                if (items.Contains(" ") || string.IsNullOrWhiteSpace(items))
+                if (items.Contains(" ") || string.IsNullOrWhiteSpace(items) || items.Contains("to") || items.Contains("by"))
                 {
                     List<string> assignments = items.Split(' ').
                         Select(x => x.Trim()).

--- a/MidasCivil_Adapter/PrivateHelpers/WriteSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/WriteSectionText.cs
@@ -22,6 +22,8 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -37,9 +39,15 @@ namespace BH.Adapter.MidasCivil
 
             using (StreamWriter sectionFile = File.CreateText(path))
             {
+                string trimText = "";
                 foreach (string text in sectionText)
                 {
-                    sectionFile.WriteLine(text);
+                    trimText = text;
+                    if(!(text.Contains("*")) && !(text.Contains(";")))
+                    {
+                        trimText = string.Join(",",text.Split(',').Select(x => x!= null ? x.Trim() : null));
+                    }    
+                    sectionFile.WriteLine(trimText);
                 }
                 sectionFile.Close();
             }
@@ -53,11 +61,16 @@ namespace BH.Adapter.MidasCivil
 
             using (StreamWriter sectionFile = File.CreateText(path))
             {
+                string trimText = "";
                 foreach (string text in sectionText)
                 {
-                    sectionFile.WriteLine(text);
+                    trimText = text;
+                    if (!(text.Contains("*")) && !(text.Contains(";")))
+                    {
+                        trimText = string.Join(",", text.Split(',').Select(x => x != null ? x.Trim() : null));
+                    }
+                    sectionFile.WriteLine(trimText);
                 }
-                sectionFile.Close();
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This toolkit allows interoperability between the BHoM and MidasCivil. It enables
 https://en.midasuser.com/product/civil_overview.asp
 
 ### Known Versions of Software Supported
-MidasCivil 2018
 
 MidasCivil 2019
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #225 
Closes #227 
Closes #228 
Closes #229 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EtPgDV8xjf5Dtu5THK-BpJ8BxZe7XfRLQ1nXUlGHHlY_Wg?e=BBh5sm

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added string.Trim() to strings being read from MCT files to ensure section names are correct 
- Fixed bug where reading `ISection` from MidasCivil used a deprecated method and produced inconceivable sections
- Fixed bug where `BarPointLoad`, BarUniformlyDistributedLoad` and `BarVaryingDistributedLoad` referenced the wrong index for `Name` properties
- Fixed bug where `GravityLoad` referenced the wrong indexes
- Removed official support for MidasCivil, the majority of functionality should still work but we are unable to test MidasCivil 2018 in particular GravityLoad which was causing issues for Midas Civil 2019 onwards 

### Additional comments
<!-- As required -->
Three tests:
1. Push to non existing - the Adapter should recognise Section1, Section2 etc. already exist and not push
2. Read a model, and then combine the files and load it in to MidasCivil. This will confirm that the trimming of properties has not affected any functionality. 
3. Added a third script to test pushing elements, loads and pulling loads