### PR TITLE
Correct bug in reading the fixity value

### DIFF
--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -36,13 +36,13 @@ namespace BH.Adapter.Adapters.MidasCivil
             List<double> stiffness = new List<double>();
 
             int constraint = 0;
-            string assignment = delimitted[1].Replace(" ",string.Empty);
+            string assignment = delimitted[1].Replace(" ", string.Empty);
 
-            if(int.TryParse(assignment, out constraint))
+            if (int.TryParse(assignment, out constraint))
             {
-                foreach(char freedom in assignment)
+                foreach (char freedom in assignment)
                 {
-                    int freedoms= int.Parse(freedom.ToString());
+                    int freedoms = int.Parse(freedom.ToString());
                     if (freedoms == 1)
                     {
                         fixity.Add(true);
@@ -58,7 +58,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                if(!(delimitted[1].Trim()=="LINEAR"))
+                if (!(delimitted[1].Trim() == "LINEAR"))
                 {
                     Engine.Reflection.Compute.RecordWarning(
                         "MidasCivil_Toolkit does not support tension/compression only springs or multi-linear springs");
@@ -66,7 +66,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    switch(version)
+                    switch (version)
                     {
                         case "8.8.5":
                             for (int i = 2; i < 8; i++)
@@ -76,10 +76,10 @@ namespace BH.Adapter.Adapters.MidasCivil
                                     fixity.Add(true);
                                     stiffness.Add(0);
                                 }
-                                else if(delimitted[i].Trim() == "NO")
+                                else if (delimitted[i].Trim() == "NO")
                                 {
                                     double spring;
-                                    if(i < 5)
+                                    if (i < 5)
                                     {
                                         spring = double.Parse(delimitted[i + 6]).ForcePerLengthToSI(forceUnit, lengthUnit);
                                     }
@@ -87,7 +87,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                                     {
                                         spring = double.Parse(delimitted[i + 6]).MomentToSI(forceUnit, lengthUnit);
                                     }
-                                    if (spring > 1E+017.ForcePerLengthToSI(forceUnit,lengthUnit) || spring > 1E+19.MomentToSI(forceUnit, lengthUnit))
+                                    if (spring > 1E+017.ForcePerLengthToSI(forceUnit, lengthUnit) || spring > 1E+19.MomentToSI(forceUnit, lengthUnit))
                                     {
                                         fixity.Add(true);
                                         stiffness.Add(0);

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -42,15 +42,15 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 foreach(char freedom in assignment)
                 {
-                    int.Parse(freedom.ToString());
-                    if (freedom == 1)
+                    int freedoms= int.Parse(freedom.ToString());
+                    if (freedoms == 1)
                     {
-                        fixity.Add(false);
+                        fixity.Add(true);
                         stiffness.Add(0.0);
                     }
                     else
                     {
-                        fixity.Add(true);
+                        fixity.Add(false);
                         stiffness.Add(0.0);
                     }
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #239 

<!-- Add short description of what has been fixed -->

The reading of  `Constraint6DOF` is corrected when pulling from Midas.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?originalPath=aHR0cHM6Ly9idXJvaGFwcG9sZC5zaGFyZXBvaW50LmNvbS86Zjovcy9CSG9NL0VvTXpaNlBnSjc5R3BuUjBNNjMtNzZ3QjdKMGVEa04tRVlMVll6VG14Y0NyWWc%5FcnRpbWU9RlBuN2tTMUMyRWc&sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FMidasCivil%5FToolkit%2FMidasCivil%5FToolkit%2D%23239

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Changed the command in converting fixity from Midas to BHoM.

### Additional comments
<!-- As required -->
@peterjamesnugent  when reviewing, you can use the test script to filter request `Constraint6DOF`. It should provide you with the correct fixity of the two test nodes. 