### PR TITLE
Added catch statement for ArguementOutOfRangeException when no MCT or Units.txt is provided 

### DIFF
--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -160,6 +160,11 @@ namespace BH.Adapter.MidasCivil
                         Engine.Reflection.Compute.RecordWarning(
                             "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
                     }
+                    catch(ArgumentOutOfRangeException)
+                    {
+                        Engine.Reflection.Compute.RecordWarning(
+                            "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #238 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EsQr7IbtAVhIqRnhqLvLtvUBAVay3L_gYfpahYup1A_84g?e=eLTcCH

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->