### PR TITLE
Implement NameOrDescriptionComparer

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
@@ -44,14 +44,14 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Bar bar in bars)
             {
-                if (bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToString() != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
+                if (new string(bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToArray()) != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
                 {
                     Engine.Reflection.Compute.RecordError("Tension only elements cannot support bar releases in Midas");
                 }
 
-                if (!(bar.Release == null) && bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToString() != "FixFix")
+                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToArray()) != "FixFix")
                 {
-                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToString(), "FRAME-RLS");
+                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), new string(bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToArray()), "FRAME-RLS");
                 }
 
                 midasElements.Add(Adapters.MidasCivil.Convert.FromBar(bar));

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
@@ -44,14 +44,14 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Bar bar in bars)
             {
-                if (new string(bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToArray()) != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
+                if (new string(bar.Release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
                 {
                     Engine.Reflection.Compute.RecordError("Tension only elements cannot support bar releases in Midas");
                 }
 
-                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToArray()) != "FixFix")
+                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) != "FixFix")
                 {
-                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), new string(bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToArray()), "FRAME-RLS");
+                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), new string(bar.Release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()), "FRAME-RLS");
                 }
 
                 midasElements.Add(Adapters.MidasCivil.Convert.FromBar(bar));

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
@@ -44,14 +44,14 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Bar bar in bars)
             {
-                if (new string(bar.Release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
+                if (new string(bar.Release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()) != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
                 {
                     Engine.Reflection.Compute.RecordError("Tension only elements cannot support bar releases in Midas");
                 }
 
-                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) != "FixFix")
+                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()) != "FixFix")
                 {
-                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), new string(bar.Release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()), "FRAME-RLS");
+                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), new string(bar.Release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()), "FRAME-RLS");
                 }
 
                 midasElements.Add(Adapters.MidasCivil.Convert.FromBar(bar));

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
@@ -20,9 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Structure.Elements;
+using BH.Engine.Structure;
+
 using System.IO;
 using System.Collections.Generic;
-using BH.oM.Structure.Elements;
+using System.Linq;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -41,14 +44,14 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Bar bar in bars)
             {
-                if (bar.Release.Name != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
+                if (bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToString() != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
                 {
                     Engine.Reflection.Compute.RecordError("Tension only elements cannot support bar releases in Midas");
                 }
 
-                if (!(bar.Release == null) && bar.Release.Name != "FixFix")
+                if (!(bar.Release == null) && bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToString() != "FixFix")
                 {
-                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), bar.Release.Name, "FRAME-RLS");
+                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), bar.Release.DescriptionOrName().Take(groupCharacterLimit).ToString(), "FRAME-RLS");
                 }
 
                 midasElements.Add(Adapters.MidasCivil.Convert.FromBar(bar));

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
@@ -20,9 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Structure;
 using BH.oM.Structure.Elements;
+
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 
 namespace BH.Adapter.MidasCivil
@@ -46,11 +49,11 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (MidasCivilAdapter.GetStiffnessVectorModulus(node.Support) > 0)
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), node.Support.Name, "SPRING");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), node.Support.DescriptionOrName().Take(groupCharacterLimit).ToString(), "SPRING");
                     }
                     else
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), node.Support.Name, "CONSTRAINT");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), node.Support.DescriptionOrName().Take(groupCharacterLimit).ToString(), "CONSTRAINT");
                     }
 
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
@@ -49,11 +49,11 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (MidasCivilAdapter.GetStiffnessVectorModulus(node.Support) > 0)
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Take(groupCharacterLimit).ToArray()), "SPRING");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()), "SPRING");
                     }
                     else
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Take(groupCharacterLimit).ToArray()), "CONSTRAINT");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()), "CONSTRAINT");
                     }
 
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
@@ -49,15 +49,15 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (MidasCivilAdapter.GetStiffnessVectorModulus(node.Support) > 0)
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()), "SPRING");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()), "SPRING");
                     }
                     else
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()), "CONSTRAINT");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()), "CONSTRAINT");
                     }
 
                 }
-                midasNodes.Add(Adapters.MidasCivil.Convert.FromNode(node, lengthUnit));
+                midasNodes.Add(Adapters.MidasCivil.Convert.FromNode(node, m_lengthUnit));
             }
 
             File.AppendAllLines(nodePath, midasNodes);

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
@@ -49,11 +49,11 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (MidasCivilAdapter.GetStiffnessVectorModulus(node.Support) > 0)
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), node.Support.DescriptionOrName().Take(groupCharacterLimit).ToString(), "SPRING");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Take(groupCharacterLimit).ToArray()), "SPRING");
                     }
                     else
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), node.Support.DescriptionOrName().Take(groupCharacterLimit).ToString(), "CONSTRAINT");
+                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Take(groupCharacterLimit).ToArray()), "CONSTRAINT");
                     }
 
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaTemperatureLoads.cs
@@ -52,7 +52,7 @@ namespace BH.Adapter.MidasCivil
 
                 foreach (string assignedFEMesh in assignedFEMeshes)
                 {
-                    midasTemperatureLoads.Add(Adapters.MidasCivil.Convert.FromAreaTemperatureLoad(areaTemperatureLoad, assignedFEMesh, temperatureUnit));
+                    midasTemperatureLoads.Add(Adapters.MidasCivil.Convert.FromAreaTemperatureLoad(areaTemperatureLoad, assignedFEMesh, m_temperatureUnit));
                 }
 
                 CompareLoadGroup(midasLoadGroup, loadGroupPath);

--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
@@ -65,7 +65,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedFEMesh in assignedFEMeshes)
                             {
-                                midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(areaUniformlyDistributedLoad, assignedFEMesh, forceUnit, lengthUnit));
+                                midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(areaUniformlyDistributedLoad, assignedFEMesh, m_forceUnit, m_lengthUnit));
                             }
                     }
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(barPointLoad, assignedBar, "Force", forceUnit, lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(barPointLoad, assignedBar, "Force", m_forceUnit, m_lengthUnit));
                             }
                         }
                         else
@@ -77,7 +77,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(barPointLoad, assignedBar, "Moment", forceUnit, lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(barPointLoad, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
                             }
                         }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarTemperatureLoads.cs
@@ -54,7 +54,7 @@ namespace BH.Adapter.MidasCivil
 
                 foreach (string assignedBar in assignedBars)
                 {
-                    midasTemperatureLoads.Add(Adapters.MidasCivil.Convert.FromBarTemperatureLoad(barTemperatureLoad, assignedBar, temperatureUnit));
+                    midasTemperatureLoads.Add(Adapters.MidasCivil.Convert.FromBarTemperatureLoad(barTemperatureLoad, assignedBar, m_temperatureUnit));
                 }
 
                 CompareLoadGroup(midasLoadGroup, loadGroupPath);

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(barUniformlyDistributedLoad, assignedBar, "Force", forceUnit, lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(barUniformlyDistributedLoad, assignedBar, "Force", m_forceUnit, m_lengthUnit));
                             }
                         }
                         else
@@ -77,7 +77,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(barUniformlyDistributedLoad, assignedBar, "Moment", forceUnit, lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(barUniformlyDistributedLoad, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
                             }
                         }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
@@ -78,7 +78,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(barVaryingDistributedLoad, assignedBar, "Force", forceUnit, lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(barVaryingDistributedLoad, assignedBar, "Force", m_forceUnit, m_lengthUnit));
                             }
                         }
                         else
@@ -88,7 +88,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(barVaryingDistributedLoad, assignedBar, "Moment", forceUnit, lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(barVaryingDistributedLoad, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
                             }
                         }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/LoadCombinations.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/LoadCombinations.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.MidasCivil
             foreach (LoadCombination loadCombination in loadCombinations)
             {
                 loadCombination.CustomData[AdapterIdName] = loadCombination.Name;
-                midasLoadCombinations.AddRange(Adapters.MidasCivil.Convert.FromLoadCombination(loadCombination, midasCivilVersion));
+                midasLoadCombinations.AddRange(Adapters.MidasCivil.Convert.FromLoadCombination(loadCombination, m_midasCivilVersion));
             }
 
             File.AppendAllLines(path, midasLoadCombinations);

--- a/MidasCivil_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.MidasCivil
             foreach (Loadcase loadcase in loadcases)
             {
                 loadcase.CustomData[AdapterIdName] = loadcase.Name;
-                Directory.CreateDirectory(directory + "\\TextFiles\\" + loadcase.Name);
+                Directory.CreateDirectory(m_directory + "\\TextFiles\\" + loadcase.Name);
                 midasLoadCases.Add(Adapters.MidasCivil.Convert.FromLoadcase(loadcase));
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/PointForce.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/PointForce.cs
@@ -47,7 +47,7 @@ namespace BH.Adapter.MidasCivil
 
                 foreach (string assignedNode in assignedNodes)
                 {
-                    midasPointLoads.Add(Adapters.MidasCivil.Convert.FromPointLoad(PointLoad, assignedNode, forceUnit, lengthUnit));
+                    midasPointLoads.Add(Adapters.MidasCivil.Convert.FromPointLoad(PointLoad, assignedNode, m_forceUnit, m_lengthUnit));
                 }
 
                 RemoveEndOfDataString(PointLoadPath);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
@@ -23,6 +23,8 @@
 using System.IO;
 using System.Collections.Generic;
 using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
+using System.Linq;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -40,11 +42,11 @@ namespace BH.Adapter.MidasCivil
 
             foreach (BarRelease release in releases)
             {
-                if (release.Name != "FixFix")
+                if (release.DescriptionOrName().Take(groupCharacterLimit).ToString() != "FixFix")
                 {
-                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(release.Name);
+                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(release.DescriptionOrName().Take(groupCharacterLimit).ToString());
                     CompareGroup(midasBoundaryGroup, boundaryGroupPath);
-                    midasBarReleases.AddRange(Adapters.MidasCivil.Convert.FromBarRelease(release));
+                    midasBarReleases.AddRange(Adapters.MidasCivil.Convert.FromBarRelease(release, groupCharacterLimit));
                 }
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
@@ -42,11 +42,11 @@ namespace BH.Adapter.MidasCivil
 
             foreach (BarRelease release in releases)
             {
-                if (release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToString() != "FixFix")
+                if (release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToString() != "FixFix")
                 {
-                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()));
+                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()));
                     CompareGroup(midasBoundaryGroup, boundaryGroupPath);
-                    midasBarReleases.AddRange(Adapters.MidasCivil.Convert.FromBarRelease(release, groupCharacterLimit));
+                    midasBarReleases.AddRange(Adapters.MidasCivil.Convert.FromBarRelease(release, m_groupCharacterLimit));
                 }
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
@@ -42,9 +42,9 @@ namespace BH.Adapter.MidasCivil
 
             foreach (BarRelease release in releases)
             {
-                if (release.DescriptionOrName().Take(groupCharacterLimit).ToString() != "FixFix")
+                if (release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToString() != "FixFix")
                 {
-                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(release.DescriptionOrName().Take(groupCharacterLimit).ToArray()));
+                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(release.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()));
                     CompareGroup(midasBoundaryGroup, boundaryGroupPath);
                     midasBarReleases.AddRange(Adapters.MidasCivil.Convert.FromBarRelease(release, groupCharacterLimit));
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
@@ -44,7 +44,7 @@ namespace BH.Adapter.MidasCivil
             {
                 if (release.DescriptionOrName().Take(groupCharacterLimit).ToString() != "FixFix")
                 {
-                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(release.DescriptionOrName().Take(groupCharacterLimit).ToString());
+                    string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(release.DescriptionOrName().Take(groupCharacterLimit).ToArray()));
                     CompareGroup(midasBoundaryGroup, boundaryGroupPath);
                     midasBarReleases.AddRange(Adapters.MidasCivil.Convert.FromBarRelease(release, groupCharacterLimit));
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Properties/Materials.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/Materials.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (IMaterialFragment material in materials)
             {
-                midasMaterials.Add(Adapters.MidasCivil.Convert.FromMaterial(material, forceUnit, lengthUnit, temperatureUnit));
+                midasMaterials.Add(Adapters.MidasCivil.Convert.FromMaterial(material, forceUnit, lengthUnit, temperatureUnit, materialCharacterLimit));
             }
 
             File.AppendAllLines(path, midasMaterials);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/Materials.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/Materials.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (IMaterialFragment material in materials)
             {
-                midasMaterials.Add(Adapters.MidasCivil.Convert.FromMaterial(material, forceUnit, lengthUnit, temperatureUnit, materialCharacterLimit));
+                midasMaterials.Add(Adapters.MidasCivil.Convert.FromMaterial(material, m_forceUnit, m_lengthUnit, m_temperatureUnit, m_materialCharacterLimit));
             }
 
             File.AppendAllLines(path, midasMaterials);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (ISectionProperty sectionProperty in sectionProperties)
             {
-                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, lengthUnit));
+                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, lengthUnit, sectionPropertyCharacterLimit));
             }
 
             File.AppendAllLines(path, midasSectionProperties);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (ISectionProperty sectionProperty in sectionProperties)
             {
-                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, lengthUnit, sectionPropertyCharacterLimit));
+                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, m_lengthUnit, m_sectionPropertyCharacterLimit));
             }
 
             File.AppendAllLines(path, midasSectionProperties);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Constraint6DOF constraint6DOF in supports)
             {
-                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()));
+                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()));
                 CompareGroup(midasBoundaryGroup, boundaryGroupPath);
             }
 
@@ -54,12 +54,12 @@ namespace BH.Adapter.MidasCivil
             {
                 if (MidasCivilAdapter.GetStiffnessVectorModulus(constraint6DOF) > 0)
                 {
-                    midasSprings.Add(Adapters.MidasCivil.Convert.FromSpring(constraint6DOF, midasCivilVersion, forceUnit, lengthUnit, groupCharacterLimit));
+                    midasSprings.Add(Adapters.MidasCivil.Convert.FromSpring(constraint6DOF, m_midasCivilVersion, m_forceUnit, m_lengthUnit, m_groupCharacterLimit));
 
                 }
                 else
                 {
-                    midasSupports.Add(Adapters.MidasCivil.Convert.FromSupport(constraint6DOF, groupCharacterLimit));
+                    midasSupports.Add(Adapters.MidasCivil.Convert.FromSupport(constraint6DOF, m_groupCharacterLimit));
                 }
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Constraint6DOF constraint6DOF in supports)
             {
-                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString());
+                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()));
                 CompareGroup(midasBoundaryGroup, boundaryGroupPath);
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
@@ -20,9 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
+
 using System.Collections.Generic;
 using System.IO;
-using BH.oM.Structure.Constraints;
+using System.Linq;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -43,7 +46,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Constraint6DOF constraint6DOF in supports)
             {
-                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(constraint6DOF.Name);
+                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString());
                 CompareGroup(midasBoundaryGroup, boundaryGroupPath);
             }
 
@@ -51,7 +54,7 @@ namespace BH.Adapter.MidasCivil
             {
                 if (MidasCivilAdapter.GetStiffnessVectorModulus(constraint6DOF) > 0)
                 {
-                    midasSprings.Add(Adapters.MidasCivil.Convert.FromSpring(constraint6DOF, midasCivilVersion, forceUnit, lengthUnit));
+                    midasSprings.Add(Adapters.MidasCivil.Convert.FromSpring(constraint6DOF, midasCivilVersion, forceUnit, lengthUnit, groupCharacterLimit));
 
                 }
                 else

--- a/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Constraint6DOF constraint6DOF in supports)
             {
-                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()));
+                string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()));
                 CompareGroup(midasBoundaryGroup, boundaryGroupPath);
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/Supports.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter.MidasCivil
                 }
                 else
                 {
-                    midasSupports.Add(Adapters.MidasCivil.Convert.FromSupport(constraint6DOF));
+                    midasSupports.Add(Adapters.MidasCivil.Convert.FromSupport(constraint6DOF, groupCharacterLimit));
                 }
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Properties/SurfaceProperty.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SurfaceProperty.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (ISurfaceProperty surfaceProperty in surfaceProperties)
             {
-                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSurfaceProperty(surfaceProperty, midasCivilVersion, lengthUnit));
+                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSurfaceProperty(surfaceProperty, midasCivilVersion, lengthUnit, groupCharacterLimit));
             }
 
             File.AppendAllLines(path, midasSectionProperties);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/SurfaceProperty.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SurfaceProperty.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (ISurfaceProperty surfaceProperty in surfaceProperties)
             {
-                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSurfaceProperty(surfaceProperty, midasCivilVersion, lengthUnit, groupCharacterLimit));
+                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSurfaceProperty(surfaceProperty, m_midasCivilVersion, m_lengthUnit, m_groupCharacterLimit));
             }
 
             File.AppendAllLines(path, midasSectionProperties);

--- a/MidasCivil_Adapter/CRUD/Delete/Elements/Element.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Elements/Element.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "ELEMENT" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "ELEMENT" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Elements/Nodes.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Elements/Nodes.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "NODE" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "NODE" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Elements/RigidLink.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Elements/RigidLink.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "RIGIDLINK" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "RIGIDLINK" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/AreaTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/AreaTemperatureLoads.cs
@@ -35,7 +35,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count()!=0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory+ "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory+ "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/AreaUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/AreaUniformlyDistributedLoads.cs
@@ -35,7 +35,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count()!=0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory+ "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory+ "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/BarPointLoads.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory + "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory + "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/BarTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/BarTemperatureLoads.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory + "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory + "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/BarUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/BarUniformlyDistributedLoads.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory + "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory + "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/BarVaryingDistributedLoads.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory + "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory + "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/GravityLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/GravityLoads.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory + "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory + "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/LoadCombinations.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/LoadCombinations.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "LOADCOMB" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "LOADCOMB" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/LoadGroup.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/LoadGroup.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "LOADGROUP" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "LOADGROUP" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/Loadcases.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/Loadcases.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "STLDCASE" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "STLDCASE" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Loads/PointForces.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Loads/PointForces.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string[] loadcaseNames = Directory.GetDirectories(directory + "\\TextFiles\\");
+                string[] loadcaseNames = Directory.GetDirectories(m_directory + "\\TextFiles\\");
 
                 foreach (string loadcaseName in loadcaseNames)
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Properties/BarReleases.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Properties/BarReleases.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "FRAME-RLS" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "FRAME-RLS" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Properties/Constraint6DOF.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Properties/Constraint6DOF.cs
@@ -39,8 +39,8 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string constraintPath = directory + "\\TextFiles\\" + "CONSTRAINT" + ".txt";
-                string springPath = directory + "\\TextFiles\\" + "SPRING" + ".txt";
+                string constraintPath = m_directory + "\\TextFiles\\" + "CONSTRAINT" + ".txt";
+                string springPath = m_directory + "\\TextFiles\\" + "SPRING" + ".txt";
                 List<string> paths = new List<string> { constraintPath, springPath };
 
                 foreach (string path in paths)

--- a/MidasCivil_Adapter/CRUD/Delete/Properties/Materials.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Properties/Materials.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "MATERIAL" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "MATERIAL" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Properties/SectionProperties.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "SECTION" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "SECTION" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Delete/Properties/SurfaceProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Delete/Properties/SurfaceProperties.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             if (ids.Count() != 0)
             {
-                string path = directory + "\\TextFiles\\" + "THICKNESS" + ".txt";
+                string path = m_directory + "\\TextFiles\\" + "THICKNESS" + ".txt";
 
                 if (File.Exists(path))
                 {

--- a/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
@@ -74,7 +74,8 @@ namespace BH.Adapter.MidasCivil
                 .Select(x => x.Split(',').ToList())
                 .ToList();
 
-            Dictionary<string, ISectionProperty> materialSections = GetSectionMaterialCombinations(materialSectionCombos, bhomMaterials, bhomSectionProperties);
+            Dictionary<string, ISectionProperty> materialSections = GetSectionMaterialCombinations(
+                materialSectionCombos, bhomMaterials, bhomSectionProperties);
 
             foreach (string bar in barText)
             {

--- a/MidasCivil_Adapter/CRUD/Read/Elements/Nodes.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/Nodes.cs
@@ -52,7 +52,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (string node in nodesText)
             {
-                Node bhomNode = Adapters.MidasCivil.Convert.ToNode(node, supports, supportAssignments, springAssignments, lengthUnit);
+                Node bhomNode = Adapters.MidasCivil.Convert.ToNode(node, supports, supportAssignments, springAssignments, m_lengthUnit);
                 int bhomID = System.Convert.ToInt32(bhomNode.CustomData[AdapterIdName]);
                 bhomNode.Tags = GetGroupAssignments(nodeGroups, bhomID);
                 bhomNodes.Add(bhomNode);

--- a/MidasCivil_Adapter/CRUD/Read/Loads/AreaTemperatureLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/AreaTemperatureLoad.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
             Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
                         x => x.Name);
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int i = 1;
 
@@ -79,7 +79,7 @@ namespace BH.Adapter.MidasCivil
 
                             AreaTemperatureLoad bhomAreaTemperatureLoad =
                                 Adapters.MidasCivil.Convert.ToAreaTemperatureLoad(
-                                    distinctFEMeshLoad, matchingFEMeshes, loadcase, loadcaseDictionary, FEMeshDictionary, i, temperatureUnit);
+                                    distinctFEMeshLoad, matchingFEMeshes, loadcase, loadcaseDictionary, FEMeshDictionary, i, m_temperatureUnit);
 
                             if (bhomAreaTemperatureLoad != null)
                                 bhomAreaTemperatureLoads.Add(bhomAreaTemperatureLoad);

--- a/MidasCivil_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoad.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
             Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
                         x => x.Name);
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int i = 1;
 
@@ -79,7 +79,7 @@ namespace BH.Adapter.MidasCivil
 
                             AreaUniformlyDistributedLoad bhomAreaUniformlyDistributedLoad =
                                 Adapters.MidasCivil.Convert.ToAreaUniformlyDistributedLoad(
-                                    distinctFEMeshLoad, matchingFEMeshes, loadcase, loadcaseDictionary, FEMeshDictionary, i, forceUnit, lengthUnit);
+                                    distinctFEMeshLoad, matchingFEMeshes, loadcase, loadcaseDictionary, FEMeshDictionary, i, m_forceUnit, m_lengthUnit);
 
                             bhomAreaUniformlyDistributedLoads.Add(bhomAreaUniformlyDistributedLoad);
 

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarPointLoads.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
             Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
                         x => x.Name);
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int j = 1;
 
@@ -107,7 +107,7 @@ namespace BH.Adapter.MidasCivil
                             List<string> matchingBars = new List<string>();
                             indexMatches.ForEach(x => matchingBars.Add(loadedBars[x]));
 
-                            BarPointLoad bhomBarPointLoad = Adapters.MidasCivil.Convert.ToBarPointLoad(distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary,1,forceUnit, lengthUnit);
+                            BarPointLoad bhomBarPointLoad = Adapters.MidasCivil.Convert.ToBarPointLoad(distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary,1,m_forceUnit, m_lengthUnit);
                             bhomBarPointLoads.Add(bhomBarPointLoad);
 
                             if (String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarTemperatureLoads.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.MidasCivil
             Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
                         x => x.Name);
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int i = 1;
 
@@ -83,7 +83,7 @@ namespace BH.Adapter.MidasCivil
 
                             BarTemperatureLoad bhomBarTemperatureLoad =
                                 Adapters.MidasCivil.Convert.ToBarTemperatureLoad(
-                                    distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, i, temperatureUnit);
+                                    distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, i, m_temperatureUnit);
 
                             if (bhomBarTemperatureLoad != null)
                                 bhomBarTemperatureLoads.Add(bhomBarTemperatureLoad);

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoad.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.MidasCivil
             Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
                         x => x.Name);
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int i = 1;
 
@@ -100,7 +100,7 @@ namespace BH.Adapter.MidasCivil
 
                             BarUniformlyDistributedLoad bhomBarUniformlyDistributedLoad =
                                 Adapters.MidasCivil.Convert.ToBarUniformlyDistributedLoad(
-                                    distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, i, forceUnit, lengthUnit);
+                                    distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, i, m_forceUnit, m_lengthUnit);
                             bhomBarUniformlyDistributedLoads.Add(bhomBarUniformlyDistributedLoad);
 
                             if(String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.MidasCivil
             Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
                         x => x.Name);
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int i = 1;
 
@@ -90,7 +90,7 @@ namespace BH.Adapter.MidasCivil
 
                             BarVaryingDistributedLoad bhomBarVaryingDistributedLoad =
                                 Adapters.MidasCivil.Convert.ToBarVaryingDistributedLoad(
-                                    distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, i, forceUnit, lengthUnit);
+                                    distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, i, m_forceUnit, m_lengthUnit);
                             bhomBarVaryingDistributedLoads.Add(bhomBarVaryingDistributedLoad);
 
 

--- a/MidasCivil_Adapter/CRUD/Read/Loads/GravityLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/GravityLoads.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.MidasCivil
 
             Engine.Reflection.Compute.RecordWarning("Note: Midas applies Self Weight to all objects in a given loadcase");
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int i = 1;
 

--- a/MidasCivil_Adapter/CRUD/Read/Loads/PointForces.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/PointForces.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.MidasCivil
             Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
                         x => x.Name);
 
-            string[] loadcaseFolders = Directory.GetDirectories(directory + "\\TextFiles");
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
 
             int i = 1;
 
@@ -79,7 +79,7 @@ namespace BH.Adapter.MidasCivil
                                                    .ToList();
                         List<string> matchingNodes = new List<string>();
                         indexMatches.ForEach(x => matchingNodes.Add(PointLoadNodes[x]));
-                        PointLoad bhomPointLoad = Adapters.MidasCivil.Convert.ToPointLoad(distinctPointLoad, matchingNodes, loadcase, loadcaseDictionary, nodeDictionary, i, forceUnit, lengthUnit);
+                        PointLoad bhomPointLoad = Adapters.MidasCivil.Convert.ToPointLoad(distinctPointLoad, matchingNodes, loadcase, loadcaseDictionary, nodeDictionary, i, m_forceUnit, m_lengthUnit);
                         bhomPointLoads.Add(bhomPointLoad);
 
                         if (String.IsNullOrWhiteSpace(distinctPointLoad.Split(',').ToList()[6]))

--- a/MidasCivil_Adapter/CRUD/Read/Properties/6DOFConstraints.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/6DOFConstraints.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.MidasCivil
             for (int i = 0; i < supports.Count; i++)
             {
                 Constraint6DOF bhomConstraint6DOF = Adapters.MidasCivil.Convert.ToConstraint6DOF(
-                    supports[i], midasCivilVersion, forceUnit, lengthUnit);
+                    supports[i], m_midasCivilVersion, m_forceUnit, m_lengthUnit);
 
                 bhom6DOFConstraints.Add(bhomConstraint6DOF);
             }
@@ -50,7 +50,7 @@ namespace BH.Adapter.MidasCivil
             for (int i = 0; i < springs.Count; i++)
             {
                 Constraint6DOF bhomConstraint6DOF = Adapters.MidasCivil.Convert.ToConstraint6DOF(
-                    springs[i], midasCivilVersion, forceUnit, lengthUnit);
+                    springs[i], m_midasCivilVersion, m_forceUnit, m_lengthUnit);
                 if (!(bhomConstraint6DOF == null))
                 {
                     bhom6DOFConstraints.Add(bhomConstraint6DOF);

--- a/MidasCivil_Adapter/CRUD/Read/Properties/Materials.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/Materials.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (string material in materialText)
             {
-                IMaterialFragment bhomMaterial = Adapters.MidasCivil.Convert.ToMaterial(material, forceUnit, lengthUnit, temperatureUnit);
+                IMaterialFragment bhomMaterial = Adapters.MidasCivil.Convert.ToMaterial(material, m_forceUnit, m_lengthUnit, m_temperatureUnit);
                 bhomMaterials.Add(bhomMaterial);
             }
 

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.MidasCivil
                     string sectionProperties3 = sectionProperties[i + 3];
 
                     bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(
-                        sectionProfile, sectionProperties1, sectionProperties2, sectionProperties3, lengthUnit);
+                        sectionProfile, sectionProperties1, sectionProperties2, sectionProperties3, m_lengthUnit);
 
                     i = i + 3;
                 }
@@ -68,7 +68,7 @@ namespace BH.Adapter.MidasCivil
                     else
                     {
                         bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(
-                            sectionProperty, lengthUnit);
+                            sectionProperty, m_lengthUnit);
                     }
 
                 }

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SurfaceProperty.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SurfaceProperty.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.MidasCivil
                 string surfaceProperty = surfaceProperties[i];
                 string type = "";
 
-                switch (midasCivilVersion)
+                switch (m_midasCivilVersion)
                 {
                     case "8.8.5":
                         type = surfaceProperty.Split(',')[2].Trim();
@@ -62,7 +62,7 @@ namespace BH.Adapter.MidasCivil
                 }
                 else if (type == "VALUE")
                 {
-                    bhomSurfaceProperty = Adapters.MidasCivil.Convert.ToSurfaceProperty(surfaceProperty, midasCivilVersion, lengthUnit);
+                    bhomSurfaceProperty = Adapters.MidasCivil.Convert.ToSurfaceProperty(surfaceProperty, m_midasCivilVersion, m_lengthUnit);
                     bhomSurfaceProperties.Add(bhomSurfaceProperty);
                 }
             }

--- a/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
@@ -74,14 +74,14 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractBarStress(List<int> ids, List<string> loadcaseIds)
         {
 
-            string filePath = directory + "\\Beam Stress.xls";
+            string filePath = m_directory + "\\Beam Stress.xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> barStressText = File.ReadAllLines(csvPath).ToList();
             List<BarStress> barStresses = new List<BarStress>();
             for (int i = 14; i < barStressText.Count; i++)
             {
                 List<string> barStress = barStressText[i].Split(',').ToList();
-                barStresses.Add(Convert.ToBarStress(barStress, forceUnit, lengthUnit));
+                barStresses.Add(Convert.ToBarStress(barStress, m_forceUnit, m_lengthUnit));
             }
 
             return barStresses;
@@ -106,14 +106,14 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractBarForce(List<int> ids, List<string> loadcaseIds)
         {
 
-            string filePath = directory + "\\Beam Force.xls";
+            string filePath = m_directory + "\\Beam Force.xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> barForceText = File.ReadAllLines(csvPath).ToList();
             List<BarForce> barForces = new List<BarForce>();
             for (int i = 11; i < barForceText.Count; i++)
             {
                 List<string> barForce = barForceText[i].Split(',').ToList();
-                barForces.Add(Convert.ToBarForce(barForce, forceUnit, lengthUnit));
+                barForces.Add(Convert.ToBarForce(barForce, m_forceUnit, m_lengthUnit));
             }
 
             return barForces;

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -81,14 +81,14 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractMeshForce(List<int> ids, List<string> loadcaseIds)
         {
             /***************************************************/
-            string filePath = directory + "\\Plate Force(UL_Local).xls";
+            string filePath = m_directory + "\\Plate Force(UL_Local).xls";
             string csvPath = ExcelToCsv(filePath);
             List<string> meshForceText = File.ReadAllLines(csvPath).ToList();
             List<MeshForce> meshForces = new List<MeshForce>();
             for (int i = 16; i < meshForceText.Count; i++)
             {
                 List<string> meshForce = meshForceText[i].Split(',').ToList();
-                meshForces.Add(Convert.ToMeshForce(meshForce, forceUnit, lengthUnit));
+                meshForces.Add(Convert.ToMeshForce(meshForce, m_forceUnit, m_lengthUnit));
             }
 
             return meshForces;
@@ -99,7 +99,7 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractMeshStress(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
         {
             /***************************************************/
-            string filePath = directory + "\\Plate Stress(L).xls";
+            string filePath = m_directory + "\\Plate Stress(L).xls";
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
             List<MeshStress> meshStresses = new List<MeshStress>();
@@ -126,7 +126,7 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractMeshVonMises(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
         {
             /***************************************************/
-            string filePath = directory + "\\Plate Stress(L).xls";
+            string filePath = m_directory + "\\Plate Stress(L).xls";
             string csvPath = ExcelToCsv(filePath);
             List<string> meshVonMisesText = File.ReadAllLines(csvPath).ToList();
             List<MeshVonMises> meshVonMiseses = new List<MeshVonMises>();

--- a/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.MidasCivil
 
         private IEnumerable<IResult> ExtractNodeReaction(List<int> ids, List<string> loadcaseIds)
         {
-            string filePath = directory + "\\Reaction(Global).xls";
+            string filePath = m_directory + "\\Reaction(Global).xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> nodeReactionText = File.ReadAllLines(csvPath).ToList();
             List<NodeReaction> nodeReactions = new List<NodeReaction>();
@@ -83,7 +83,7 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (ids.Contains(System.Convert.ToInt32(nodeReaction[2])) && loadcaseIds.Contains(nodeReaction[3]))
                     {
-                        nodeReactions.Add(Adapters.MidasCivil.Convert.ToNodeReaction(nodeReaction, forceUnit, lengthUnit));
+                        nodeReactions.Add(Adapters.MidasCivil.Convert.ToNodeReaction(nodeReaction, m_forceUnit, m_lengthUnit));
                     }
                 }
 
@@ -96,7 +96,7 @@ namespace BH.Adapter.MidasCivil
 
         private IEnumerable<IResult> ExtractNodeDisplacement(List<int> ids, List<string> loadcaseIds)
         {
-            string filePath = directory + "\\Displacements(Global).xls";
+            string filePath = m_directory + "\\Displacements(Global).xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> nodeDisplacementText = File.ReadAllLines(csvPath).ToList();
 
@@ -112,7 +112,7 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (ids.Contains(System.Convert.ToInt32(nodeDisplacement[2])) && loadcaseIds.Contains(nodeDisplacement[3]))
                     {
-                        nodeDisplacements.Add(Adapters.MidasCivil.Convert.ToNodeDisplacement(nodeDisplacement, lengthUnit));
+                        nodeDisplacements.Add(Adapters.MidasCivil.Convert.ToNodeDisplacement(nodeDisplacement, m_lengthUnit));
                     }
                 }
             }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToMaterials.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToMaterials.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     density = (double.Parse(delimited[13].Trim()) / 9.806).DensityToSI(forceUnit, lengthUnit);
                 }
             }
-            else if(delimited.Count() == 24)
+            else if (delimited.Count() == 24)
             {
                 density = double.Parse(delimited[23].Trim()).DensityToSI(forceUnit, lengthUnit);
                 if (density == 0)

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromBarRelease.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromBarRelease.cs
@@ -55,7 +55,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                                     FromDOFType(barRelease.EndRelease.RotationZ);
 
             midasRelease.Add(",NO," + startFixity + ",0,0,0,0,0,0");
-            midasRelease.Add(endFixity + ",0,0,0,0,0,0," + new string(barRelease.DescriptionOrName().Take(groupCharacterLimit).ToArray()));
+            midasRelease.Add(endFixity + ",0,0,0,0,0,0," + new string(barRelease.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()));
 
             return midasRelease;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromBarRelease.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromBarRelease.cs
@@ -55,7 +55,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                                     FromDOFType(barRelease.EndRelease.RotationZ);
 
             midasRelease.Add(",NO," + startFixity + ",0,0,0,0,0,0");
-            midasRelease.Add(endFixity + ",0,0,0,0,0,0," + barRelease.DescriptionOrName().Take(groupCharacterLimit).ToString());
+            midasRelease.Add(endFixity + ",0,0,0,0,0,0," + new string(barRelease.DescriptionOrName().Take(groupCharacterLimit).ToArray()));
 
             return midasRelease;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromBarRelease.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromBarRelease.cs
@@ -20,8 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Structure;
 using BH.oM.Structure.Constraints;
+
+using System.IO;
 using System.Collections.Generic;
+using System.Linq;
+using BH.Adapter.MidasCivil;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -31,7 +36,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static List<string> FromBarRelease(this BarRelease barRelease)
+        public static List<string> FromBarRelease(this BarRelease barRelease, int groupCharacterLimit)
         {
             List<string> midasRelease = new List<string>();
 
@@ -50,7 +55,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                                     FromDOFType(barRelease.EndRelease.RotationZ);
 
             midasRelease.Add(",NO," + startFixity + ",0,0,0,0,0,0");
-            midasRelease.Add(endFixity + ",0,0,0,0,0,0," + barRelease.Name);
+            midasRelease.Add(endFixity + ",0,0,0,0,0,0," + barRelease.DescriptionOrName().Take(groupCharacterLimit).ToString());
 
             return midasRelease;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
@@ -23,7 +23,7 @@
 using System.Collections.Generic;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Structure;
-using BH.oM.Structure.Results;
+using System.Linq;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -33,7 +33,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromMaterial(this IMaterialFragment material, string forceUnit, string lengthUnit, string temperatureUnit)
+        public static string FromMaterial(this IMaterialFragment material, string forceUnit, string lengthUnit, string temperatureUnit, int materialCharacterLimit)
         {
             string type = "";
             if (!(material.IMaterialType() == MaterialType.Steel || material.IMaterialType() == MaterialType.Concrete))
@@ -56,31 +56,18 @@ namespace BH.Adapter.Adapters.MidasCivil
                 IIsotropic isotropic = material as IIsotropic;
                 midasMaterial = (
                     isotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    isotropic.Name + ",0,0,,C,NO," +
+                    isotropic.DescriptionOrName().Take(materialCharacterLimit).ToString() + ",0,0,,C,NO," +
                     isotropic.DampingRatio + ",2," + isotropic.YoungsModulus.PressureFromSI(forceUnit, lengthUnit) + "," +
                     isotropic.PoissonsRatio + "," + isotropic.ThermalExpansionCoeff.InverseDeltaTemperatureFromSI(temperatureUnit) + "," +
                     isotropic.Density.DensityFromSI(forceUnit, lengthUnit) * 9.806 + "," + isotropic.Density.DensityFromSI(forceUnit, lengthUnit)
                 );
-
-
-
-                string s2 = isotropic.Name;
-                int count2 = 0;
-                foreach (char c in s2)
-                {
-                    count2++;
-                }
-                if (count2 > 16)
-                {
-                    Engine.Reflection.Compute.RecordWarning("All names must be under 16 characters");
-                }
             }
             else if (material is IOrthotropic)
             {
                 IOrthotropic iorthotropic = material as IOrthotropic;
                 midasMaterial = (
                      iorthotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    iorthotropic.Name + ",0,0,,C,NO," +
+                    iorthotropic.DescriptionOrName().Take(materialCharacterLimit).ToString() + ",0,0,,C,NO," +
                     iorthotropic.DampingRatio + ",3,"
                     +   iorthotropic.YoungsModulus.X.PressureFromSI(forceUnit, lengthUnit) + "," + 
                         iorthotropic.YoungsModulus.Y.PressureFromSI(forceUnit, lengthUnit) + "," + 
@@ -94,18 +81,6 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + iorthotropic.PoissonsRatio.X + "," + iorthotropic.PoissonsRatio.Y + "," + iorthotropic.PoissonsRatio.Z + ","
                     + iorthotropic.Density.DensityFromSI(forceUnit, lengthUnit) * 9.806 + "," + iorthotropic.Density.DensityFromSI(forceUnit, lengthUnit)
                 );
-
-                string s = iorthotropic.Name;
-                int count = 0;
-                foreach (char c in s)
-                {
-                    count++;
-                }
-
-                if (count > 16)
-                {
-                    Engine.Reflection.Compute.RecordWarning("All names must be under 16 characters");
-                }
             }
             return midasMaterial;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 IIsotropic isotropic = material as IIsotropic;
                 midasMaterial = (
                     isotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    isotropic.DescriptionOrName().Take(materialCharacterLimit).ToString() + ",0,0,,C,NO," +
+                    new string(isotropic.DescriptionOrName().Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
                     isotropic.DampingRatio + ",2," + isotropic.YoungsModulus.PressureFromSI(forceUnit, lengthUnit) + "," +
                     isotropic.PoissonsRatio + "," + isotropic.ThermalExpansionCoeff.InverseDeltaTemperatureFromSI(temperatureUnit) + "," +
                     isotropic.Density.DensityFromSI(forceUnit, lengthUnit) * 9.806 + "," + isotropic.Density.DensityFromSI(forceUnit, lengthUnit)
@@ -67,7 +67,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 IOrthotropic iorthotropic = material as IOrthotropic;
                 midasMaterial = (
                      iorthotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    iorthotropic.DescriptionOrName().Take(materialCharacterLimit).ToString() + ",0,0,,C,NO," +
+                    new string(iorthotropic.DescriptionOrName().Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
                     iorthotropic.DampingRatio + ",3,"
                     +   iorthotropic.YoungsModulus.X.PressureFromSI(forceUnit, lengthUnit) + "," + 
                         iorthotropic.YoungsModulus.Y.PressureFromSI(forceUnit, lengthUnit) + "," + 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 IIsotropic isotropic = material as IIsotropic;
                 midasMaterial = (
                     isotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    new string(isotropic.DescriptionOrName().Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
+                    new string(isotropic.DescriptionOrName().Replace(",","").Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
                     isotropic.DampingRatio + ",2," + isotropic.YoungsModulus.PressureFromSI(forceUnit, lengthUnit) + "," +
                     isotropic.PoissonsRatio + "," + isotropic.ThermalExpansionCoeff.InverseDeltaTemperatureFromSI(temperatureUnit) + "," +
                     isotropic.Density.DensityFromSI(forceUnit, lengthUnit) * 9.806 + "," + isotropic.Density.DensityFromSI(forceUnit, lengthUnit)
@@ -67,7 +67,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 IOrthotropic iorthotropic = material as IOrthotropic;
                 midasMaterial = (
                      iorthotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    new string(iorthotropic.DescriptionOrName().Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
+                    new string(iorthotropic.DescriptionOrName().Replace(",","").Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
                     iorthotropic.DampingRatio + ",3,"
                     +   iorthotropic.YoungsModulus.X.PressureFromSI(forceUnit, lengthUnit) + "," + 
                         iorthotropic.YoungsModulus.Y.PressureFromSI(forceUnit, lengthUnit) + "," + 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             else
             {
                 string midasSectionProperty = sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
-                 sectionProperty.DescriptionOrName().Take(sectionPropertyCharacterLimit).ToString() + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
+                 new string(sectionProperty.DescriptionOrName().Take(sectionPropertyCharacterLimit).ToArray()) + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
                  CreateSection(sectionProperty as dynamic, lengthUnit);
 
                 return midasSectionProperty;

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             else
             {
                 string midasSectionProperty = sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
-                 new string(sectionProperty.DescriptionOrName().Take(sectionPropertyCharacterLimit).ToArray()) + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
+                 new string(sectionProperty.DescriptionOrName().Replace(",","").Take(sectionPropertyCharacterLimit).ToArray()) + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
                  CreateSection(sectionProperty as dynamic, lengthUnit);
 
                 return midasSectionProperty;

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -23,6 +23,8 @@
 using System;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
+using BH.Engine.Structure;
+using System.Linq;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -32,7 +34,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromSectionProperty(this ISectionProperty sectionProperty, string lengthUnit)
+        public static string FromSectionProperty(this ISectionProperty sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
             if (CreateSection(sectionProperty as dynamic, lengthUnit) == null)
             {
@@ -41,19 +43,9 @@ namespace BH.Adapter.Adapters.MidasCivil
             else
             {
                 string midasSectionProperty = sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
-                 sectionProperty.Name + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
+                 sectionProperty.DescriptionOrName().Take(sectionPropertyCharacterLimit).ToString() + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
                  CreateSection(sectionProperty as dynamic, lengthUnit);
 
-                string s3 = sectionProperty.Name;
-                int count3 = 0;
-                foreach (char c in s3)
-                {
-                    count3++;
-                }
-                if (count3 > 16)
-                {
-                    Engine.Reflection.Compute.RecordWarning("All names must be under 16 characters");
-                }
                 return midasSectionProperty;
             }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         stiffness[0].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[1].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[2].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[3].MomentFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[4].MomentFromSI(forceUnit, lengthUnit) + "," + stiffness[5].MomentFromSI(forceUnit, lengthUnit)
-                        + "," + "NO, 0, 0, 0, 0, 0, 0," + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + "," + "0, 0, 0, 0, 0"
+                        + "," + "NO, 0, 0, 0, 0, 0, 0," + new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) + "," + "0, 0, 0, 0, 0"
                         );
                     break;
                 default:
@@ -59,7 +59,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         stiffness[0].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[1].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[2].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[3].MomentFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[4].MomentFromSI(forceUnit, lengthUnit) + "," + stiffness[5].MomentFromSI(forceUnit, lengthUnit)
-                        + "," + "NO, 0, 0, 0, 0, 0, 0," + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + "," + "0, 0, 0, 0, 0"
+                        + "," + "NO, 0, 0, 0, 0, 0, 0," + new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) + "," + "0, 0, 0, 0, 0"
                         );
                     break;
             }
@@ -136,7 +136,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 if (!(MidasCivilAdapter.GetSupportedDOFType(freedom)))
                 {
                     Engine.Reflection.Compute.RecordWarning(
-                        "Unsupported DOFType in " + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + " assumed to be" + DOFType.Fixed);
+                        "Unsupported DOFType in " + new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) + " assumed to be" + DOFType.Fixed);
                     support = support + "YES,";
                 }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
@@ -20,9 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
 using BH.Adapter.MidasCivil;
 using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
+
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -32,7 +35,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromSpring(this Constraint6DOF constraint6DOF, string version, string forceUnit, string lengthUnit)
+        public static string FromSpring(this Constraint6DOF constraint6DOF, string version, string forceUnit, string lengthUnit, int groupCharacterLimit)
         {
             List<double> stiffness = SpringStiffness(constraint6DOF, forceUnit, lengthUnit);
 
@@ -41,13 +44,13 @@ namespace BH.Adapter.Adapters.MidasCivil
             switch (version)
             {
                 case "8.8.5":
-                    string springFixity = SpringFixity(constraint6DOF);
+                    string springFixity = SpringFixity(constraint6DOF, groupCharacterLimit);
                     midasSpring = (
                         " " + "," + "LINEAR" + "," + springFixity +
                         stiffness[0].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[1].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[2].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[3].MomentFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[4].MomentFromSI(forceUnit, lengthUnit) + "," + stiffness[5].MomentFromSI(forceUnit, lengthUnit)
-                        + "," + "NO, 0, 0, 0, 0, 0, 0," + constraint6DOF.Name + "," + "0, 0, 0, 0, 0"
+                        + "," + "NO, 0, 0, 0, 0, 0, 0," + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + "," + "0, 0, 0, 0, 0"
                         );
                     break;
                 default:
@@ -56,7 +59,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         stiffness[0].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[1].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[2].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[3].MomentFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[4].MomentFromSI(forceUnit, lengthUnit) + "," + stiffness[5].MomentFromSI(forceUnit, lengthUnit)
-                        + "," + "NO, 0, 0, 0, 0, 0, 0," + constraint6DOF.Name + "," + "0, 0, 0, 0, 0"
+                        + "," + "NO, 0, 0, 0, 0, 0, 0," + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + "," + "0, 0, 0, 0, 0"
                         );
                     break;
             }
@@ -118,7 +121,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         /***************************************************/
 
-        private static string SpringFixity(Constraint6DOF constraint6DOF)
+        private static string SpringFixity(Constraint6DOF constraint6DOF, int groupCharacterLimit)
         {
             List<DOFType> freedoms = new List<DOFType>
             {
@@ -133,7 +136,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 if (!(MidasCivilAdapter.GetSupportedDOFType(freedom)))
                 {
                     Engine.Reflection.Compute.RecordWarning(
-                        "Unsupported DOFType in " + constraint6DOF.Name + " assumed to be" + DOFType.Fixed);
+                        "Unsupported DOFType in " + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + " assumed to be" + DOFType.Fixed);
                     support = support + "YES,";
                 }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         stiffness[0].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[1].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[2].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[3].MomentFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[4].MomentFromSI(forceUnit, lengthUnit) + "," + stiffness[5].MomentFromSI(forceUnit, lengthUnit)
-                        + "," + "NO, 0, 0, 0, 0, 0, 0," + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + "," + "0, 0, 0, 0, 0"
+                        + "," + "NO, 0, 0, 0, 0, 0, 0," + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + "," + "0, 0, 0, 0, 0"
                         );
                     break;
                 default:
@@ -59,7 +59,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         stiffness[0].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[1].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[2].ForcePerLengthFromSI(forceUnit, lengthUnit) + "," + stiffness[3].MomentFromSI(forceUnit, lengthUnit) + "," +
                         stiffness[4].MomentFromSI(forceUnit, lengthUnit) + "," + stiffness[5].MomentFromSI(forceUnit, lengthUnit)
-                        + "," + "NO, 0, 0, 0, 0, 0, 0," + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + "," + "0, 0, 0, 0, 0"
+                        + "," + "NO, 0, 0, 0, 0, 0, 0," + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + "," + "0, 0, 0, 0, 0"
                         );
                     break;
             }
@@ -136,7 +136,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 if (!(MidasCivilAdapter.GetSupportedDOFType(freedom)))
                 {
                     Engine.Reflection.Compute.RecordWarning(
-                        "Unsupported DOFType in " + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + " assumed to be" + DOFType.Fixed);
+                        "Unsupported DOFType in " + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + " assumed to be" + DOFType.Fixed);
                     support = support + "YES,";
                 }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         public static string FromSupport(this Constraint6DOF constraint6DOF, int groupCharacterLimit)
         {
             string midasSupport = " " + "," + SupportString(constraint6DOF, groupCharacterLimit) + "," +
-                 constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString();
+                 new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray());
 
             return midasSupport;
         }
@@ -74,7 +74,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     else
                     {
                         Engine.Reflection.Compute.RecordWarning(
-                                     "Unsupported DOFType in " + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + " assumed to be" + DOFType.Free);
+                                     "Unsupported DOFType in " + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + " assumed to be" + DOFType.Free);
                         support = support + "0";
                     }
                 }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
@@ -20,10 +20,14 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+
+using BH.Adapter.MidasCivil;
+using BH.Engine.Structure;
+using BH.oM.Structure.Constraints;
+
 using System.IO;
 using System.Collections.Generic;
-using BH.oM.Structure.Constraints;
-using BH.Adapter.MidasCivil;
+using System.Linq;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -33,13 +37,10 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromSupport(this Constraint6DOF constraint6DOF)
+        public static string FromSupport(this Constraint6DOF constraint6DOF, int groupCharacterLimit)
         {
-            string midasSupport = (
-                 " " + "," +
-                 SupportString(constraint6DOF) + "," +
-                 constraint6DOF.Name
-                 );
+            string midasSupport = " " + "," + SupportString(constraint6DOF) + "," +
+                 constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString();
 
             return midasSupport;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         public static string FromSupport(this Constraint6DOF constraint6DOF, int groupCharacterLimit)
         {
             string midasSupport = " " + "," + SupportString(constraint6DOF, groupCharacterLimit) + "," +
-                 new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray());
+                 new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray());
 
             return midasSupport;
         }
@@ -74,7 +74,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     else
                     {
                         Engine.Reflection.Compute.RecordWarning(
-                                     "Unsupported DOFType in " + new string(constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToArray()) + " assumed to be" + DOFType.Free);
+                                     "Unsupported DOFType in " + new string(constraint6DOF.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray()) + " assumed to be" + DOFType.Free);
                         support = support + "0";
                     }
                 }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSupport.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         public static string FromSupport(this Constraint6DOF constraint6DOF, int groupCharacterLimit)
         {
-            string midasSupport = " " + "," + SupportString(constraint6DOF) + "," +
+            string midasSupport = " " + "," + SupportString(constraint6DOF, groupCharacterLimit) + "," +
                  constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString();
 
             return midasSupport;
@@ -49,7 +49,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static string SupportString(Constraint6DOF constraint6DOF)
+        private static string SupportString(Constraint6DOF constraint6DOF, int groupCharacterLimit)
         {
             List<DOFType> freedoms = new List<DOFType>
             {
@@ -74,7 +74,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     else
                     {
                         Engine.Reflection.Compute.RecordWarning(
-                                     "Unsupported DOFType in " + constraint6DOF.Name + " assumed to be" + DOFType.Free);
+                                     "Unsupported DOFType in " + constraint6DOF.DescriptionOrName().Take(groupCharacterLimit).ToString() + " assumed to be" + DOFType.Free);
                         support = support + "0";
                     }
                 }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
                     case "8.8.5":
                         midasSurfaceProperty =
-                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + "," + new string(bhomSurfaceProperty.DescriptionOrName().Take(groupCharacterLimit).ToArray())
+                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + "," + new string(bhomSurfaceProperty.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray())
                         + ",VALUE,Yes," + bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,Yes,0,0";
                         break;
                     default:

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
@@ -20,8 +20,12 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
+
+using BH.Engine.Structure;
 using BH.oM.Structure.SurfaceProperties;
+
+using System;
+using System.Linq;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -31,9 +35,9 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromSurfaceProperty(this ISurfaceProperty surfaceProperty, string version, string lengthUnit)
+        public static string FromSurfaceProperty(this ISurfaceProperty surfaceProperty, string version, string lengthUnit, int groupCharacterLimit)
         {
-            string midasSurfaceProperty = CreateSurfaceProfile(surfaceProperty as dynamic, version, lengthUnit);
+            string midasSurfaceProperty = CreateSurfaceProfile(surfaceProperty as dynamic, version, lengthUnit, groupCharacterLimit);
 
             return midasSurfaceProperty;
         }
@@ -42,7 +46,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static string CreateSurfaceProfile(ConstantThickness bhomSurfaceProperty, string version, string lengthUnit)
+        private static string CreateSurfaceProfile(ConstantThickness bhomSurfaceProperty, string version, string lengthUnit, int groupCharacterLimit)
         {
             if (bhomSurfaceProperty.Thickness == 0)
             {
@@ -56,8 +60,8 @@ namespace BH.Adapter.Adapters.MidasCivil
 
                     case "8.8.5":
                         midasSurfaceProperty =
-                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + "," + bhomSurfaceProperty.Name + ",VALUE,Yes," +
-                        bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,Yes,0,0";
+                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + "," + bhomSurfaceProperty.DescriptionOrName().Take(groupCharacterLimit).ToString()
+                        + ",VALUE,Yes," + bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,Yes,0,0";
                         break;
                     default:
                         midasSurfaceProperty =

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
                     case "8.8.5":
                         midasSurfaceProperty =
-                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + "," + bhomSurfaceProperty.DescriptionOrName().Take(groupCharacterLimit).ToString()
+                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + "," + new string(bhomSurfaceProperty.DescriptionOrName().Take(groupCharacterLimit).ToArray())
                         + ",VALUE,Yes," + bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,Yes,0,0";
                         break;
                     default:

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromTag.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromTag.cs
@@ -32,14 +32,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         public static string FromTag(string name)
         {
-            //Check what AUTOTYPE is, seems auto set to 0
-
-            string midasBoundaryGroup = (
-                name + "," +
-                "0"
-            );
-
-            return midasBoundaryGroup;
+            return name + "," + "0";
         }
 
         /***************************************************/

--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -34,7 +34,7 @@ using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Loads;
 using BH.Engine.Adapters.MidasCivil.Comparer;
-
+using BH.Engine.Structure;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -56,20 +56,20 @@ namespace BH.Adapter.MidasCivil
 
                 AdapterComparers = new Dictionary<Type, object>
                 {
-                    {typeof(Node), new Engine.Structure.NodeDistanceComparer(3) },   //The 3 in here sets how many decimal places to look at for node merging. 3 decimal places gives mm precision
+                    {typeof(Node), new NodeDistanceComparer(3) },   //The 3 in here sets how many decimal places to look at for node merging. 3 decimal places gives mm precision
                     {typeof(Bar), new BarMidPointComparer(3) },
                     {typeof(FEMesh), new MeshCentreComparer() },
-                    {typeof(Constraint6DOF), new BHoMObjectNameComparer() },
-                    {typeof(RigidLink), new BHoMObjectNameComparer() },
-                    {typeof(BarRelease), new BHoMObjectNameComparer() },
-                    {typeof(SteelSection), new BHoMObjectNameComparer() },
-                    {typeof(ISectionProperty), new BHoMObjectNameComparer() },
-                    {typeof(Steel), new BHoMObjectNameComparer() },
-                    {typeof(Concrete), new BHoMObjectNameComparer() },
-                    {typeof(IMaterialFragment), new BHoMObjectNameComparer() },
-                    {typeof(LinkConstraint), new BHoMObjectNameComparer() },
-                    {typeof(ConstantThickness), new BHoMObjectNameComparer() },
-                    {typeof(ISurfaceProperty), new BHoMObjectNameComparer() },
+                    {typeof(Constraint6DOF), new NameOrDescriptionComparer() },
+                    {typeof(RigidLink), new NameOrDescriptionComparer() },
+                    {typeof(BarRelease), new NameOrDescriptionComparer() },
+                    {typeof(SteelSection), new NameOrDescriptionComparer() },
+                    {typeof(ISectionProperty), new NameOrDescriptionComparer() },
+                    {typeof(Steel), new NameOrDescriptionComparer() },
+                    {typeof(Concrete), new NameOrDescriptionComparer() },
+                    {typeof(IMaterialFragment), new NameOrDescriptionComparer() },
+                    {typeof(LinkConstraint), new NameOrDescriptionComparer() },
+                    {typeof(ConstantThickness), new NameOrDescriptionComparer() },
+                    {typeof(ISurfaceProperty), new NameOrDescriptionComparer() },
                     {typeof(Loadcase), new BHoMObjectNameComparer() },
                     {typeof(PointLoad), new BHoMObjectNameComparer() },
                     {typeof(GravityLoad), new BHoMObjectNameComparer() },

--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -176,6 +176,9 @@ namespace BH.Adapter.MidasCivil
         public string lengthUnit;
         public string heatUnit;
         public string temperatureUnit;
+        public int groupCharacterLimit = 80;
+        public int sectionPropertyCharacterLimit = 28;
+        public int materialCharacterLimit = 16;
         private Dictionary<Type, Dictionary<int, HashSet<string>>> m_tags = new Dictionary<Type, Dictionary<int, HashSet<string>>>();
 
 

--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -111,49 +111,49 @@ namespace BH.Adapter.MidasCivil
                     {
                         throw new Exception("File does not exist, please reference an .mcb file");
                     }
-                    directory = Path.GetDirectoryName(filePath);
+                    m_directory = Path.GetDirectoryName(filePath);
                     string fileName = Path.GetFileNameWithoutExtension(filePath);
-                    string txtFile = directory + "\\" + fileName + ".txt";
-                    string mctFile = directory + "\\" + fileName + ".mct";
+                    string txtFile = m_directory + "\\" + fileName + ".txt";
+                    string mctFile = m_directory + "\\" + fileName + ".mct";
 
                     if (File.Exists(txtFile))
                     {
-                        midasText = File.ReadAllLines(txtFile).ToList();
+                        m_midasText = File.ReadAllLines(txtFile).ToList();
                         SetSectionText();
                     }
                     else if (File.Exists(mctFile))
                     {
-                        midasText = File.ReadAllLines(mctFile).ToList();
+                        m_midasText = File.ReadAllLines(mctFile).ToList();
                         SetSectionText();
                     }
-                    string versionFile = directory + "\\TextFiles\\" + "VERSION" + ".txt";
-                    midasCivilVersion = "8.8.1";
+                    string versionFile = m_directory + "\\TextFiles\\" + "VERSION" + ".txt";
+                    m_midasCivilVersion = "8.8.1";
 
                     if (!(version == ""))
                     {
-                        midasCivilVersion = version.Trim();
+                        m_midasCivilVersion = version.Trim();
                         if (File.Exists(versionFile))
                         {
-                            Engine.Reflection.Compute.RecordWarning("*VERSION file found, user input used to overide: version =  " + midasCivilVersion);
+                            Engine.Reflection.Compute.RecordWarning("*VERSION file found, user input used to overide: version =  " + m_midasCivilVersion);
                         }
                     }
                     else if (File.Exists(versionFile))
                     {
                         List<string> versionText = GetSectionText("VERSION");
-                        midasCivilVersion = versionText[0].Trim();
+                        m_midasCivilVersion = versionText[0].Trim();
                     }
                     else
                     {
-                        Engine.Reflection.Compute.RecordWarning("*VERSION file not found in directory and no version specified, MidasCivil version assumed default value =  " + midasCivilVersion);
+                        Engine.Reflection.Compute.RecordWarning("*VERSION file not found in directory and no version specified, MidasCivil version assumed default value =  " + m_midasCivilVersion);
                     }
 
                     try
                     {
                         List<string> units = GetSectionText("UNIT")[0].Split(',').ToList();
-                        forceUnit = units[0].Trim();
-                        lengthUnit = units[1].Trim();
-                        heatUnit = units[2].Trim();
-                        temperatureUnit = units[3].Trim();
+                        m_forceUnit = units[0].Trim();
+                        m_lengthUnit = units[1].Trim();
+                        m_heatUnit = units[2].Trim();
+                        m_temperatureUnit = units[3].Trim();
                     }
                     catch(DirectoryNotFoundException)
                     {
@@ -169,26 +169,21 @@ namespace BH.Adapter.MidasCivil
             return (Process.GetProcessesByName("CVlw").Length > 0) ? true : false;
         }
 
-        public List<string> midasText;
-        public string directory;
-        public string midasCivilVersion;
-        public string forceUnit;
-        public string lengthUnit;
-        public string heatUnit;
-        public string temperatureUnit;
-        public int groupCharacterLimit = 80;
-        public int sectionPropertyCharacterLimit = 28;
-        public int materialCharacterLimit = 16;
-        private Dictionary<Type, Dictionary<int, HashSet<string>>> m_tags = new Dictionary<Type, Dictionary<int, HashSet<string>>>();
-
-
         /***************************************************/
         /**** Private  Fields                           ****/
         /***************************************************/
 
-        //Add any comlink object as a private field here, example named:
-
-        //private SoftwareComLink m_softwareNameCom;
+        private List<string> m_midasText;
+        private string m_directory;
+        private string m_midasCivilVersion;
+        private string m_forceUnit;
+        private string m_lengthUnit;
+        private string m_heatUnit;
+        private string m_temperatureUnit;
+        private readonly int m_groupCharacterLimit = 80;
+        private readonly int m_sectionPropertyCharacterLimit = 28;
+        private readonly int m_materialCharacterLimit = 15;
+        private Dictionary<Type, Dictionary<int, HashSet<string>>> m_tags = new Dictionary<Type, Dictionary<int, HashSet<string>>>();
 
         /***************************************************/
     }

--- a/MidasCivil_Adapter/PrivateHelpers/AssignBarRelease.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/AssignBarRelease.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.MidasCivil
 
         private void AssignBarRelease(string bhomID, string propertyName, string section)
         {
-            string path = directory + "\\TextFiles\\" + section + ".txt";
+            string path = m_directory + "\\TextFiles\\" + section + ".txt";
 
             List<string> propertyText = File.ReadAllLines(path).ToList();
 

--- a/MidasCivil_Adapter/PrivateHelpers/AssignProperty.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/AssignProperty.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.MidasCivil
 
         private void AssignProperty(string bhomID, string propertyName, string section)
         {
-            string path = directory + "\\TextFiles\\" + section + ".txt";
+            string path = m_directory + "\\TextFiles\\" + section + ".txt";
 
             List<string> propertyText = File.ReadAllLines(path).ToList();
 

--- a/MidasCivil_Adapter/PrivateHelpers/CreateGroups.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/CreateGroups.cs
@@ -94,7 +94,7 @@ namespace BH.Adapter.MidasCivil
             }
 
             List<string> totalKeys = groupsToAdd.Keys.ToList();
-            File.Delete(directory + "\\TextFiles\\GROUP.txt");
+            File.Delete(m_directory + "\\TextFiles\\GROUP.txt");
             string path = CreateSectionFile("GROUP");
 
 
@@ -177,7 +177,7 @@ namespace BH.Adapter.MidasCivil
             }
 
             List<string> totalKeys = groupsToAdd.Keys.ToList();
-            File.Delete(directory + "\\TextFiles\\GROUP.txt");
+            File.Delete(m_directory + "\\TextFiles\\GROUP.txt");
             string path = CreateSectionFile("GROUP");
 
 
@@ -258,7 +258,7 @@ namespace BH.Adapter.MidasCivil
             }
 
             List<string> totalKeys = groupsToAdd.Keys.ToList();
-            File.Delete(directory + "\\TextFiles\\GROUP.txt");
+            File.Delete(m_directory + "\\TextFiles\\GROUP.txt");
             string path = CreateSectionFile("GROUP");
 
 

--- a/MidasCivil_Adapter/PrivateHelpers/CreateSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/CreateSectionText.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.MidasCivil
 
         private string CreateSectionFile(string section)
         {
-            string newFolder = directory + "\\TextFiles\\";
+            string newFolder = m_directory + "\\TextFiles\\";
             System.IO.Directory.CreateDirectory(newFolder);
             string path = newFolder + "\\" + section + ".txt";
 

--- a/MidasCivil_Adapter/PrivateHelpers/ExistsSection.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/ExistsSection.cs
@@ -32,7 +32,7 @@ namespace BH.Adapter.MidasCivil
 
         private bool ExistsSection(string section)
         {
-            string path = directory + "\\TextFiles\\" + section + ".txt";
+            string path = m_directory + "\\TextFiles\\" + section + ".txt";
 
             if (File.Exists(path))
             {

--- a/MidasCivil_Adapter/PrivateHelpers/GetSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/GetSectionText.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.MidasCivil
 
         private List<string> GetSectionText(string section)
         {
-            string path = directory + "\\TextFiles\\" + section + ".txt";
+            string path = m_directory + "\\TextFiles\\" + section + ".txt";
             List<string> sectionText = new List<string>();
 
             if (File.Exists(path))

--- a/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
@@ -33,17 +33,17 @@ namespace BH.Adapter.MidasCivil
 
         public void SetSectionText()
         {
-            List<int> sectionIndexes = midasText.Select((value, index) => new { value, index })
+            List<int> sectionIndexes = m_midasText.Select((value, index) => new { value, index })
                 .Where(x => x.ToString().Contains("*"))
                 .Select(x => x.index)
                 .ToList();
 
-            List<int> loadcaseStarts = midasText.Select((value, index) => new { value, index })
+            List<int> loadcaseStarts = m_midasText.Select((value, index) => new { value, index })
                 .Where(x => x.ToString().Contains("*USE-STLD"))
                 .Select(x => x.index)
                 .ToList();
 
-            List<int> loadcaseEnds = midasText.Select((value, index) => new { value, index })
+            List<int> loadcaseEnds = m_midasText.Select((value, index) => new { value, index })
                 .Where(x => x.ToString().Contains("; End of data for load case"))
                 .Select(x => x.index)
                 .ToList();
@@ -63,7 +63,7 @@ namespace BH.Adapter.MidasCivil
                 int sectionStart = sectionIndexes[i];
                 int sectionEnd = sectionIndexes[i + 1] - 1;
 
-                string sectionHeader = midasText[sectionStart];
+                string sectionHeader = m_midasText[sectionStart];
 
                 if (!(sectionHeader[0] == '*') || loadSectionIndexes.Contains(sectionStart))
                 {
@@ -71,7 +71,7 @@ namespace BH.Adapter.MidasCivil
                 }
 
                 string sectionName = SectionName(sectionHeader);
-                List<string> sectionText = midasText.GetRange(sectionStart, sectionEnd - sectionStart);
+                List<string> sectionText = m_midasText.GetRange(sectionStart, sectionEnd - sectionStart);
 
                 if (loadcaseStarts.Contains(sectionStart))
                 {
@@ -86,13 +86,13 @@ namespace BH.Adapter.MidasCivil
                     {
                         int loadStart = sectionIndexes[k];
                         int loadEnd = sectionIndexes[k + 1] - 1;
-                        string loadHeader = midasText[loadStart];
-                        List<string> loadText = midasText.GetRange(loadStart, loadEnd - loadStart);
+                        string loadHeader = m_midasText[loadStart];
+                        List<string> loadText = m_midasText.GetRange(loadStart, loadEnd - loadStart);
                         if (!(loadHeader[0] == '*'))
                         {
                             continue;
                         }
-                        string loadName = SectionName(midasText[loadStart]);
+                        string loadName = SectionName(m_midasText[loadStart]);
                         WriteSectionText(loadText, loadName, path);
                     }
                 }

--- a/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
@@ -76,7 +76,7 @@ namespace BH.Adapter.MidasCivil
                 if (loadcaseStarts.Contains(sectionStart))
                 {
                     string loadcaseName = sectionHeader.Split(',')[1].Replace(" ", "");
-                    string path = directory + "\\TextFiles\\" + loadcaseName;
+                    string path = m_directory + "\\TextFiles\\" + loadcaseName;
                     System.IO.Directory.CreateDirectory(path);
                     WriteSectionText(sectionText, sectionName, path);
 

--- a/MidasCivil_Adapter/PrivateHelpers/WriteSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/WriteSectionText.cs
@@ -35,7 +35,7 @@ namespace BH.Adapter.MidasCivil
 
         private void WriteSectionText(List<string> sectionText, string section)
         {
-            string path = directory + "\\TextFiles\\" + section + ".txt";
+            string path = m_directory + "\\TextFiles\\" + section + ".txt";
 
             using (StreamWriter sectionFile = File.CreateText(path))
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #211 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/ErYxsQQnezpAtxAuxtB84TgBN4xUaRQ-_vaFCdd8KZ6NBA?e=NK7R4m

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- The `NameOrDescriptionComparer` will auto create names based on object properties for `Material`, `Constraint6DOF`, `SectionProperty` and `SurfaceProperty`
- Note that MidasCivil has limits for Material names (16 characters), SectionProperty names (28) and Group names (80)
- Group names are used where the MidasCivil object does not have a name parameter such as thicknesses and supports
- In the instance where the description or name exceeds the character limit only the first `n` characters will be used

### Additional comments
<!-- As required -->
@IsakNaslundBh given the limitation on string length and nature of the input text, I've had to shortern the names and also remove any commas (only in the Material description I believe). There's also the question of special characters as it seems to come out as something else entirely.

Are we happy that it provides some sort fall back method (and is not perfect):
![image](https://user-images.githubusercontent.com/30078587/92301427-d1414700-ef5b-11ea-9deb-2a157b7112d2.png)
