### PR TITLE
Added support for creating and reading TaperedProfile

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (ISectionProperty sectionProperty in sectionProperties)
             {
-                midasSectionProperties.Add(Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, m_lengthUnit, m_sectionPropertyCharacterLimit));
+                midasSectionProperties.AddRange(Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, m_lengthUnit, m_sectionPropertyCharacterLimit));
             }
 
             File.AppendAllLines(path, midasSectionProperties);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -39,7 +39,9 @@ namespace BH.Adapter.MidasCivil
 
             foreach (ISectionProperty sectionProperty in sectionProperties)
             {
-                midasSectionProperties.AddRange(Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, m_lengthUnit, m_sectionPropertyCharacterLimit));
+                List<string> midasSectionProperty = Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, m_lengthUnit, m_sectionPropertyCharacterLimit);
+                if (midasSectionProperty != null)
+                    midasSectionProperties.AddRange(midasSectionProperty);
             }
 
             File.AppendAllLines(path, midasSectionProperties);

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -76,7 +76,7 @@ namespace BH.Adapter.MidasCivil
                     else
                     {
                         List<string> split = sectionProperty.Split(',').ToList();
-                        bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(split.GetRange(14, numberColumns - 16), 
+                        bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(split.GetRange(14, numberColumns - 16),
                             split[12].Trim(), m_lengthUnit);
 
                         bhomSectionProperty.Name = split[2].Trim();

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -20,7 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Structure.SectionProperties;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -41,7 +43,7 @@ namespace BH.Adapter.MidasCivil
             for (int i = 0; i < sectionProperties.Count; i++)
             {
                 string sectionProperty = sectionProperties[i];
-                string type = sectionProperty.Split(',')[1].Replace(" ", "");
+                string type = sectionProperty.Split(',')[1].Trim();
 
                 ISectionProperty bhomSectionProperty = null;
 
@@ -52,8 +54,14 @@ namespace BH.Adapter.MidasCivil
                     string sectionProperties2 = sectionProperties[i + 2];
                     string sectionProperties3 = sectionProperties[i + 3];
 
+                    List<string> split = sectionProfile.Split(',').ToList();
+
                     bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(
-                        sectionProfile, sectionProperties1, sectionProperties2, sectionProperties3, m_lengthUnit);
+                        split.GetRange(14, sectionProperty.Split(',').Count() - 15), sectionProperties1, sectionProperties2, sectionProperties3,
+                        split[12].Trim(), m_lengthUnit);
+
+                    bhomSectionProperty.Name = split[2].Trim();
+                    bhomSectionProperty.CustomData[AdapterIdName] = split[0].Trim();
 
                     i = i + 3;
                 }
@@ -67,10 +75,27 @@ namespace BH.Adapter.MidasCivil
                     }
                     else
                     {
-                        bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(
-                            sectionProperty, m_lengthUnit);
-                    }
+                        List<string> split = sectionProperty.Split(',').ToList();
+                        bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(split.GetRange(14, numberColumns - 16), 
+                            split[12].Trim(), m_lengthUnit);
 
+                        bhomSectionProperty.Name = split[2].Trim();
+                        bhomSectionProperty.CustomData[AdapterIdName] = split[0].Trim();
+                    }
+                }
+                else if (type == "TAPERED")
+                {
+                    List<string> split = sectionProperty.Split(',').ToList();
+                    List<string> profiles = sectionProperties[i + 1].Split(',').ToList();
+                    string shape = split[14].Trim();
+                    string interpolationOrder = Math.Max(System.Convert.ToInt32(split[15].Trim()), System.Convert.ToInt32(split[16].Trim())).ToString();
+
+                    bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(profiles, "TAPERED" + "-" + shape + "-" + interpolationOrder, m_lengthUnit);
+
+                    bhomSectionProperty.CustomData[AdapterIdName] = split[0].Trim();
+                    bhomSectionProperty.Name = split[2].Trim();
+
+                    i = i + 1;
                 }
                 else
                 {

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Geometry.ShapeProfiles;
+using System.Collections.Generic;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -30,77 +31,78 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static IProfile ToProfile(string sectionProfile, string lengthUnit)
+        public static IProfile ToProfile(List<string> sectionProfile, string shape, string lengthUnit)
         {
-            string[] split = sectionProfile.Split(',');
-            string shape = split[12].Trim();
-
             IProfile bhomProfile = null;
-            if (shape == "SB")
+            switch (shape)
             {
-                bhomProfile = Engine.Geometry.Create.RectangleProfile(
-                    System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit), 0);
-            }
-            else if (shape == "B")
-            {
-                double width = System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit);
-                double webSpacing = System.Convert.ToDouble(split[18]).LengthToSI(lengthUnit);
-                double webThickness = System.Convert.ToDouble(split[16]).LengthToSI(lengthUnit);
-                double corbel;
-                if (System.Math.Abs(width / 2 - webSpacing / 2 - webThickness / 2) < oM.Geometry.Tolerance.Distance)
-                {
-                    corbel = 0;
-                }
+                case "SB":
+                    bhomProfile = Engine.Geometry.Create.RectangleProfile(
+                        System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit), 0);
+                    break;
+                case "B":
+                    double width = System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit);
+                    double webSpacing = System.Convert.ToDouble(sectionProfile[4]).LengthToSI(lengthUnit);
+                    double webThickness = System.Convert.ToDouble(sectionProfile[2]).LengthToSI(lengthUnit);
+                    double corbel;
+                    if (System.Math.Abs(width / 2 - webSpacing / 2 - webThickness / 2) < oM.Geometry.Tolerance.Distance)
+                    {
+                        corbel = 0;
+                    }
 
-                else
-                {
-                    corbel = (width / 2 - webSpacing / 2 - webThickness / 2).LengthToSI(lengthUnit);
-                }
+                    else
+                    {
+                        corbel = (width / 2 - webSpacing / 2 - webThickness / 2).LengthToSI(lengthUnit);
+                    }
 
-                bhomProfile = Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(
-                        System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), width, webThickness,
-                        System.Convert.ToDouble(split[17]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[19]).LengthToSI(lengthUnit),
-                        corbel, corbel
-                );
+                    bhomProfile = Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(
+                            System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit), width, webThickness,
+                            System.Convert.ToDouble(sectionProfile[3]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[5]).LengthToSI(lengthUnit),
+                            corbel, corbel);
+                    break;
+                case "P":
+                    bhomProfile = Engine.Geometry.Create.TubeProfile(System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit),
+                        System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit));
+                    break;
+                case "SR":
+                    bhomProfile = Engine.Geometry.Create.CircleProfile(
+                         System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit));
+                    break;
+                case "H":
+                    bhomProfile = Engine.Geometry.Create.FabricatedISectionProfile(
+                        System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit),
+                        System.Convert.ToDouble(sectionProfile[4]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[2]).LengthToSI(lengthUnit),
+                        System.Convert.ToDouble(sectionProfile[3]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[5]).LengthToSI(lengthUnit), 0);
+                    break;
+                case "T":
+                    bhomProfile = Engine.Geometry.Create.TSectionProfile(
+                        System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit),
+                        System.Convert.ToDouble(sectionProfile[2]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[3]).LengthToSI(lengthUnit),
+                        0, 0);
+                    break;
+                case "C":
+                    bhomProfile = Engine.Geometry.Create.ChannelProfile(
+                            System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit),
+                            System.Convert.ToDouble(sectionProfile[2]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[3]).LengthToSI(lengthUnit),
+                            System.Convert.ToDouble(sectionProfile[6]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[7]).LengthToSI(lengthUnit));
+                    break;
+                case "L":
+                    bhomProfile = Engine.Geometry.Create.AngleProfile(
+                            System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit),
+                            System.Convert.ToDouble(sectionProfile[2]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[3]).LengthToSI(lengthUnit),
+                            0, 0, false, true);
+                    break;
             }
-            else if (shape == "P")
+
+            if (shape.Contains("TAPERED"))
             {
-                bhomProfile = Engine.Geometry.Create.TubeProfile(System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit),
-                    System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit));
-            }
-            else if (shape == "SR")
-            {
-                bhomProfile = Engine.Geometry.Create.CircleProfile(
-                     System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit));
-            }
-            else if (shape == "H")
-            {
-                bhomProfile = Engine.Geometry.Create.FabricatedISectionProfile(
-                    System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit),
-                    System.Convert.ToDouble(split[18]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[16]).LengthToSI(lengthUnit),
-                    System.Convert.ToDouble(split[17]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[19]).LengthToSI(lengthUnit), 0);
-            }
-            else if (shape == "T")
-            {
-                bhomProfile = Engine.Geometry.Create.TSectionProfile(
-                    System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit),
-                    System.Convert.ToDouble(split[16]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[17]).LengthToSI(lengthUnit),
-                    0, 0
-                    );
-            }
-            else if (shape == "C")
-            {
-                bhomProfile = Engine.Geometry.Create.ChannelProfile(
-                        System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit),
-                        System.Convert.ToDouble(split[16]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[17]).LengthToSI(lengthUnit),
-                        System.Convert.ToDouble(split[20]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[21]).LengthToSI(lengthUnit));
-            }
-            else if (shape == "L")
-            {
-                bhomProfile = Engine.Geometry.Create.AngleProfile(
-                        System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit),
-                        System.Convert.ToDouble(split[16]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[17]).LengthToSI(lengthUnit),
-                        0, 0, false, true);
+                string shapeCode = shape.Split('-')[1].Trim();
+                int interpolationOrder = System.Convert.ToInt32(shape.Split('-')[2].Trim());
+                IProfile startProfile = Convert.ToProfile(sectionProfile.GetRange(0, sectionProfile.Count / 2), shapeCode, lengthUnit);
+                IProfile endProfile = Convert.ToProfile(sectionProfile.GetRange(sectionProfile.Count / 2, sectionProfile.Count / 2), shapeCode, lengthUnit);
+
+                bhomProfile = Engine.Geometry.Create.TaperedProfile(startProfile, endProfile, interpolationOrder);
+
             }
 
             return bhomProfile;

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
@@ -98,11 +98,10 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 string shapeCode = shape.Split('-')[1].Trim();
                 int interpolationOrder = System.Convert.ToInt32(shape.Split('-')[2].Trim());
-                IProfile startProfile = Convert.ToProfile(sectionProfile.GetRange(0, sectionProfile.Count / 2), shapeCode, lengthUnit);
-                IProfile endProfile = Convert.ToProfile(sectionProfile.GetRange(sectionProfile.Count / 2, sectionProfile.Count / 2), shapeCode, lengthUnit);
-
+                int midIndex = sectionProfile.Count / 2;
+                IProfile startProfile = Convert.ToProfile(sectionProfile.GetRange(0, midIndex), shapeCode, lengthUnit);
+                IProfile endProfile = Convert.ToProfile(sectionProfile.GetRange(midIndex, midIndex), shapeCode, lengthUnit);
                 bhomProfile = Engine.Geometry.Create.TaperedProfile(startProfile, endProfile, interpolationOrder);
-
             }
 
             return bhomProfile;

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSectionProperty.cs
@@ -26,6 +26,8 @@ using BH.oM.Geometry.ShapeProfiles;
 using BH.Engine.Structure;
 using System;
 using System.Linq;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -35,95 +37,18 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static ISectionProperty ToSectionProperty(this string sectionProperty, string lengthUnit)
+        public static ISectionProperty ToSectionProperty(this List<string> sectionProperty, string shape, string lengthUnit)
         {
-            string[] split = sectionProperty.Split(',');
-            string shape = split[12].Trim();
-
-            GenericSection bhomSection = null;
-
-            if (shape == "SB")
-            {
-                //    2, DBUSER    , USER-RECTANGLE    , CC, 0, 0, 0, 0, 0, 0, YES, NO, SB , 2, 0.5, 0.5, 0, 0, 0, 0, 0, 0, 0, 0
-                bhomSection = Create.GenericSectionFromProfile(Create.RectangleProfile
-                    (System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit), 0), null);
-
-            }
-            else if (shape == "B")
-            {
-                //    4, DBUSER    , USER-BOX          , CC, 0, 0, 0, 0, 0, 0, YES, NO, B  , 2, 0.5, 0.2, 0.01, 0.02, 0.19, 0.02, 0, 0, 0, 0
-                bhomSection = Create.GenericSectionFromProfile(Convert.ToProfile(sectionProperty, lengthUnit), null
-                    );
-
-
-            }
-            else if (shape == "P")
-            {
-                //    6, DBUSER    , CHS 114.3x9.83    , CC, 0, 0, 0, 0, 0, 0, YES, NO, P  , 1, BS, CHS 114.3x9.83
-                bhomSection = Create.GenericSectionFromProfile(
-                    Create.TubeProfile(System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit))
-                    , null);
-
-            }
-            else if (shape == "SR")
-            {
-                //14, DBUSER    , USER - CIRCLE       , CC, 0, 0, 0, 0, 0, 0, YES, NO, SR , 2, 0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0
-                bhomSection = Create.GenericSectionFromProfile(
-                    Create.CircleProfile(System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit)), null);
-
-            }
-            else if (shape == "H")
-            {
-                bhomSection = Create.GenericSectionFromProfile(Engine.Geometry.Create.FabricatedISectionProfile
-                    (System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit),
-                    System.Convert.ToDouble(split[18]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[16]).LengthToSI(lengthUnit),
-                    System.Convert.ToDouble(split[17]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[19]).LengthToSI(lengthUnit), 0), null);
-
-                //    8, DBUSER    , USER-ISECTION     , CC, 0, 0, 0, 0, 0, 0, YES, NO, H  , 2, 1, 0.3, 0.03, 0.025, 0.5, 0.02, 0.01, 0.01, 0, 0
-            }
-            else if (shape == "T")
-            {
-                bhomSection = Create.GenericSectionFromProfile(Create.TSectionProfile
-                    (System.Convert.ToDouble(split[14]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[15]).LengthToSI(lengthUnit),
-                    System.Convert.ToDouble(split[16]).LengthToSI(lengthUnit), System.Convert.ToDouble(split[17]).LengthToSI(lengthUnit), 0, 0), null);
-
-                //   10, DBUSER    , USER-TSECTION     , CC, 0, 0, 0, 0, 0, 0, YES, NO, T  , 2, 0.3, 0.2, 0.02, 0.05, 0, 0, 0, 0, 0, 0
-            }
-            else if (shape == "C")
-            {
-                //   12, DBUSER    , USER-CHANNEL      , CC, 0, 0, 0, 0, 0, 0, YES, NO, C  , 2, 0.9, 0.5, 0.02, 0.02, 0.5, 0.02, 0, 0, 0, 0
-
-                bhomSection = Create.GenericSectionFromProfile(ToProfile(sectionProperty, lengthUnit), null);
-
-
-                Engine.Reflection.Compute.RecordWarning(bhomSection.SectionProfile.GetType().ToString() +
-                    " has identical flanges. Therefore, the top flange width and thickness have been used from MidasCivil.");
-            }
-            else if (shape == "L")
-            {
-                //    1, DBUSER    , USERANGLE         , CC, 0, 0, 0, 0, 0, 0, YES, NO, L  , 2, 0.5, 0.25, 0.01, 0.03, 0, 0, 0, 0, 0, 0
-                bhomSection = Create.GenericSectionFromProfile(
-                        ToProfile(sectionProperty, lengthUnit), null);
-            }
-            else
-            {
-                Engine.Reflection.Compute.RecordError("Section not yet supported in MidasCivil_Toolkit ");
-            }
-
-            bhomSection.Name = split[2];
-            bhomSection.CustomData[AdapterIdName] = split[0].Replace(" ", "");
-
-            return bhomSection;
+            return Create.GenericSectionFromProfile(Convert.ToProfile(sectionProperty, shape, lengthUnit), null);
         }
 
         /***************************************************/
 
-        public static ISectionProperty ToSectionProperty(this string sectionProfile, string sectionProperty1,
-            string sectionProperty2, string sectionProperty3, string lengthUnit)
+        public static ISectionProperty ToSectionProperty(this List<string> sectionProfile, string sectionProperty1,
+            string sectionProperty2, string sectionProperty3, string shape, string lengthUnit)
         {
-            IProfile bhomProfile = ToProfile(sectionProfile, lengthUnit);
+            IProfile bhomProfile = ToProfile(sectionProfile, shape, lengthUnit);
 
-            string[] split0 = sectionProfile.Split(',');
             string[] split1 = sectionProperty1.Split(',');
             string[] split2 = sectionProperty2.Split(',');
             string[] split3 = sectionProperty3.Split(',');
@@ -150,16 +75,9 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             bhomProfile = Compute.Integrate(bhomProfile, oM.Geometry.Tolerance.MicroDistance).Item1;
 
-            GenericSection bhomSection = new GenericSection(
+            return new GenericSection(
                 bhomProfile, area, rgy, rgz, j, iy, iz, iw,
                 wely, welz, wply, wplz, centreZ, centreY, zt, zb, yt, yb, asy, asz);
-
-
-
-            bhomSection.Name = split0[2];
-            bhomSection.CustomData[AdapterIdName] = split0[0].Trim();
-
-            return bhomSection;
         }
 
         /***************************************************/

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -21,10 +21,13 @@
  */
 
 using System;
+using System.Collections.Generic;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.Engine.Structure;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
+using Microsoft.SqlServer.Server;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -34,69 +37,117 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromSectionProperty(this ISectionProperty sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
+        public static List<string> FromSectionProperty(this ISectionProperty sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
-            if (CreateSection(sectionProperty as dynamic, lengthUnit) == null)
-            {
-                return null;
-            }
-            else
-            {
-                string midasSectionProperty = sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
-                 new string(sectionProperty.DescriptionOrName().Replace(",","").Take(sectionPropertyCharacterLimit).ToArray()) + ",CC, 0, 0, 0, 0, 0, 0, YES, NO," +
-                 CreateSection(sectionProperty as dynamic, lengthUnit);
+            List<string> midasSectionProperty = new List<string>();
+            midasSectionProperty = CreateSection(sectionProperty as dynamic, lengthUnit, sectionPropertyCharacterLimit);
 
-                return midasSectionProperty;
-            }
-
+            return midasSectionProperty is null ? null : midasSectionProperty;
         }
 
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static string CreateSection(SteelSection sectionProperty, string lengthUnit)
+        private static List<string> CreateSection(SteelSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
-            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit);
+            List<string> midasSectionProperty = new List<string>();
+            if(sectionProperty.SectionProfile is TaperedProfile)
+            {
+                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED" +
+                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                    "CC, 0,0,0,0,0,0,0,0,YES,NO" + GetShapeCode(sectionProperty) + GetInterpolationOrder(sectionProperty) + GetInterpolationOrder(sectionProperty) + "USER");
+                midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+            else
+            {
+                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) + 
+                    ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
 
             return midasSectionProperty;
         }
 
         /***************************************************/
 
-        private static string CreateSection(ConcreteSection sectionProperty, string lengthUnit)
+        private static List<string> CreateSection(ConcreteSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
-            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit);
+            List<string> midasSectionProperty = new List<string>();
+            if (sectionProperty.SectionProfile is TaperedProfile)
+            {
+                midasSectionProperty.AddRange(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+            else
+            {
+                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                    ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+
             return midasSectionProperty;
         }
 
         /***************************************************/
 
-        private static string CreateSection(TimberSection sectionProperty, string lengthUnit)
+        private static List<string> CreateSection(TimberSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
-            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit);
+            List<string> midasSectionProperty = new List<string>();
+            if (sectionProperty.SectionProfile is TaperedProfile)
+            {
+                midasSectionProperty.AddRange(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+            else
+            {
+                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                    ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+
             return midasSectionProperty;
         }
 
         /***************************************************/
 
-        private static string CreateSection(GenericSection sectionProperty, string lengthUnit)
+        private static List<string> CreateSection(GenericSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
-            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit);
+            List<string> midasSectionProperty = new List<string>();
+            if (sectionProperty.SectionProfile is TaperedProfile)
+            {
+                midasSectionProperty.AddRange(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+            else
+            {
+                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                    ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+
             return midasSectionProperty;
         }
 
         /***************************************************/
 
-        private static string CreateSection(AluminiumSection sectionProperty, string lengthUnit)
+        private static List<string> CreateSection(AluminiumSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
-            string midasSectionProperty = CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit);
+            List<string> midasSectionProperty = new List<string>();
+            if (sectionProperty.SectionProfile is TaperedProfile)
+            {
+                midasSectionProperty.AddRange(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+            else
+            {
+                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                    ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+            }
+
             return midasSectionProperty;
         }
 
         /***************************************************/
 
-        private static string CreateSection(ExplicitSection sectionProperty, string lengthUnit)
+        private static string CreateSection(ExplicitSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
             Engine.Reflection.Compute.RecordError("ExplicitSection not supported in MidasCivil_Toolkit");
             return null;
@@ -288,6 +339,52 @@ namespace BH.Adapter.Adapters.MidasCivil
                 profilearray[profileindex - 1] + " not supported in MidasCivil_Toolkit"
                 );
             return null;
+        }
+
+        /***************************************************/
+
+        private static string CreateProfile(TaperedProfile profile, string lengthUnit)
+        {
+            List<IProfile> profiles = new List<IProfile>(profile.Profiles.Values);
+
+            return CreateProfile(profiles[0] as dynamic, lengthUnit) + CreateProfile(profiles[profiles.Count-1] as dynamic, lengthUnit);
+        }
+
+        /***************************************************/
+
+        private static string GetInterpolationOrder(ISectionProperty sectionProperty)
+        {
+            GenericSection genericSection = (GenericSection)sectionProperty;
+            TaperedProfile taperedProfile = (TaperedProfile)genericSection.SectionProfile;
+            List<int> interpolationOrders = taperedProfile.InterpolationOrder;
+
+            return interpolationOrders.Max().ToString();
+        }
+
+        /***************************************************/
+        private static string GetShapeCode(ISectionProperty sectionProperty)
+        {
+            GenericSection genericSection = (GenericSection)sectionProperty;
+            IProfile profile = genericSection.SectionProfile;
+
+            if (profile is GeneralisedFabricatedBoxProfile || profile is FabricatedBoxProfile || profile is BoxProfile)
+                return "B";
+            else if (profile is FabricatedISectionProfile || profile is ISectionProfile)
+                return "I";
+            else if (profile is RectangleProfile)
+                return "SB";
+            else if (profile is CircleProfile)
+                return "SR";
+            else if (profile is TubeProfile)
+                return "P";
+            else if (profile is TSectionProfile)
+                return "T";
+            else if (profile is AngleProfile)
+                return "L";
+            else if (profile is ChannelProfile)
+                return "C";
+            else
+                return null;
         }
 
         /***************************************************/

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -38,9 +38,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         public static List<string> FromSectionProperty(this ISectionProperty sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
-            List<string> midasSectionProperty = CreateSection(sectionProperty as dynamic, lengthUnit, sectionPropertyCharacterLimit);
-
-            return midasSectionProperty == null ? null : midasSectionProperty;
+            return CreateSection(sectionProperty as dynamic, lengthUnit, sectionPropertyCharacterLimit) ?? null;
         }
 
         /***************************************************/
@@ -50,17 +48,28 @@ namespace BH.Adapter.Adapters.MidasCivil
         private static List<string> CreateSection(SteelSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
             List<string> midasSectionProperty = new List<string>();
-            if(sectionProperty.SectionProfile is TaperedProfile)
+            if (sectionProperty.SectionProfile is TaperedProfile)
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
-                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                    ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + ",USER");
-                midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                TaperedProfile taperedProfile = (TaperedProfile)sectionProperty.SectionProfile;
+                List<IProfile> profiles = new List<IProfile>(taperedProfile.Profiles.Values);
+                if (profiles.Any(x => x.Shape != profiles.First().Shape))
+                {
+                    Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
+                    return null;
+                }
+                else
+                {
+                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
+                        "," + GetInterpolationOrder(sectionProperty) + ",USER");
+                    midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                }
             }
             else
             {
                 midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
-                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) + 
+                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
 
@@ -74,10 +83,21 @@ namespace BH.Adapter.Adapters.MidasCivil
             List<string> midasSectionProperty = new List<string>();
             if (sectionProperty.SectionProfile is TaperedProfile)
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
-                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                    ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + ",USER");
-                midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                TaperedProfile taperedProfile = (TaperedProfile)sectionProperty.SectionProfile;
+                List<IProfile> profiles = new List<IProfile>(taperedProfile.Profiles.Values);
+                if (profiles.Any(x => x.Shape != profiles.First().Shape))
+                {
+                    Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
+                    return null;
+                }
+                else
+                {
+                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
+                        "," + GetInterpolationOrder(sectionProperty) + ",USER");
+                    midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                }
             }
             else
             {
@@ -96,10 +116,21 @@ namespace BH.Adapter.Adapters.MidasCivil
             List<string> midasSectionProperty = new List<string>();
             if (sectionProperty.SectionProfile is TaperedProfile)
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
-                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                    ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + ",USER");
-                midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                TaperedProfile taperedProfile = (TaperedProfile)sectionProperty.SectionProfile;
+                List<IProfile> profiles = new List<IProfile>(taperedProfile.Profiles.Values);
+                if (profiles.Any(x => x.Shape != profiles.First().Shape))
+                {
+                    Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
+                    return null;
+                }
+                else
+                {
+                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
+                        "," + GetInterpolationOrder(sectionProperty) + ",USER");
+                    midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                }
             }
             else
             {
@@ -118,10 +149,21 @@ namespace BH.Adapter.Adapters.MidasCivil
             List<string> midasSectionProperty = new List<string>();
             if (sectionProperty.SectionProfile is TaperedProfile)
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
-                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                    ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + ",USER");
-                midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                TaperedProfile taperedProfile = (TaperedProfile)sectionProperty.SectionProfile;
+                List<IProfile> profiles = new List<IProfile>(taperedProfile.Profiles.Values);
+                if (profiles.Any(x => x.Shape != profiles.First().Shape))
+                {
+                    Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
+                    return null;
+                }
+                else
+                {
+                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
+                        "," + GetInterpolationOrder(sectionProperty) + ",USER");
+                    midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                }
             }
             else
             {
@@ -140,10 +182,21 @@ namespace BH.Adapter.Adapters.MidasCivil
             List<string> midasSectionProperty = new List<string>();
             if (sectionProperty.SectionProfile is TaperedProfile)
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
-                    new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                    ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) + ",USER");
-                midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                TaperedProfile taperedProfile = (TaperedProfile)sectionProperty.SectionProfile;
+                List<IProfile> profiles = new List<IProfile>(taperedProfile.Profiles.Values);
+                if (profiles.Any(x => x.Shape != profiles.First().Shape))
+                {
+                    Engine.Reflection.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
+                    return null;
+                }
+                else
+                {
+                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
+                        "," + GetInterpolationOrder(sectionProperty) + ",USER");
+                    midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
+                }
             }
             else
             {
@@ -160,6 +213,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         private static string CreateSection(ExplicitSection sectionProperty, string lengthUnit, int sectionPropertyCharacterLimit)
         {
             Engine.Reflection.Compute.RecordError("ExplicitSection not supported in MidasCivil_Toolkit");
+
             return null;
         }
 
@@ -167,9 +221,8 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         private static string CreateProfile(RectangleProfile profile, string lengthUnit)
         {
-            string midasSectionProperty = "SB, 2," +
-                profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) +
-                " ,0, 0, 0, 0, 0, 0, 0, 0";
+            string midasSectionProperty = "SB, 2," + profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + " ,0, 0, 0, 0, 0, 0, 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -178,11 +231,11 @@ namespace BH.Adapter.Adapters.MidasCivil
         private static string CreateProfile(BoxProfile profile, string lengthUnit)
         {
             double webSpacing = (profile.Width - profile.Thickness).LengthFromSI(lengthUnit);
-
             string midasSectionProperty = "B, 2," +
                 profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + "," + profile.Thickness.LengthFromSI(lengthUnit) + "," +
                 profile.Thickness.LengthFromSI(lengthUnit) + "," + webSpacing + "," + profile.Thickness.LengthFromSI(lengthUnit) +
                 ", 0, 0, 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -191,11 +244,11 @@ namespace BH.Adapter.Adapters.MidasCivil
         private static string CreateProfile(FabricatedBoxProfile profile, string lengthUnit)
         {
             double webSpacing = (profile.Width - profile.WebThickness).LengthFromSI(lengthUnit);
-
             string midasSectionProperty = "B, 2," +
                 profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + "," + profile.WebThickness.LengthFromSI(lengthUnit) + "," +
                 profile.TopFlangeThickness.LengthFromSI(lengthUnit) + "," + webSpacing + "," + profile.BotFlangeThickness.LengthFromSI(lengthUnit) +
                 ", 0, 0, 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -206,6 +259,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             string midasSectionProperty = "SR, 2," +
                 profile.Diameter.LengthFromSI(lengthUnit) +
                 ", 0, 0, 0, 0, 0, 0, 0, 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -216,6 +270,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             string midasSectionProperty = "P  , 2," +
                 profile.Diameter.LengthFromSI(lengthUnit) + "," + profile.Thickness.LengthFromSI(lengthUnit) +
                 ", 0, 0, 0, 0, 0, 0, 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -227,6 +282,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 profile.WebThickness.LengthFromSI(lengthUnit) + "," + profile.FlangeThickness.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + "," +
                 profile.FlangeThickness.LengthFromSI(lengthUnit) + "," + profile.RootRadius.LengthFromSI(lengthUnit) + "," + profile.ToeRadius.LengthFromSI(lengthUnit) +
                 ", 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -237,6 +293,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             string midasSectionProperty = "T, 2," + profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + "," +
                 profile.WebThickness.LengthFromSI(lengthUnit) + "," + profile.FlangeThickness.LengthFromSI(lengthUnit) +
                 ",0, 0, 0, 0, 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -248,10 +305,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 profile.WebThickness.LengthFromSI(lengthUnit) + "," + profile.TopFlangeThickness.LengthFromSI(lengthUnit) + "," + profile.BotFlangeWidth.LengthFromSI(lengthUnit) + "," +
                 profile.BotFlangeThickness.LengthFromSI(lengthUnit) + "," + profile.WeldSize.LengthFromSI(lengthUnit) +
                 ", 0, 0, 0";
-
-            Engine.Reflection.Compute.RecordWarning(
-                "The weld size has been assumed equal to the root radius"
-                );
+            Engine.Reflection.Compute.RecordWarning("The weld size for the FabiricatedISectionProfile been assumed equal to the root radius parameter in MidasCivil");
 
             return midasSectionProperty;
         }
@@ -271,9 +325,10 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         private static string CreateProfile(ChannelProfile profile, string lengthUnit)
         {
-            string midasSectionProperty = "C  , 2," + profile.Height.LengthFromSI(lengthUnit) + "," + profile.FlangeWidth.LengthFromSI(lengthUnit) + "," + 
-                profile.WebThickness.LengthFromSI(lengthUnit) + "," + profile.FlangeThickness.LengthFromSI(lengthUnit) + "," + 
+            string midasSectionProperty = "C  , 2," + profile.Height.LengthFromSI(lengthUnit) + "," + profile.FlangeWidth.LengthFromSI(lengthUnit) + "," +
+                profile.WebThickness.LengthFromSI(lengthUnit) + "," + profile.FlangeThickness.LengthFromSI(lengthUnit) + "," +
                 profile.FlangeWidth.LengthFromSI(lengthUnit) + "," + profile.FlangeThickness.LengthFromSI(lengthUnit) + ", 0, 0, 0, 0";
+
             return midasSectionProperty;
         }
 
@@ -286,15 +341,13 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 webSpacing = (profile.Width - profile.TopLeftCorbelWidth - profile.TopRightCorbelWidth - profile.WebThickness).LengthFromSI(lengthUnit);
             }
-
             string midasSectionProperty = "B, 2," +
                 profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + "," + profile.WebThickness.LengthFromSI(lengthUnit) + "," +
                 profile.TopFlangeThickness.LengthFromSI(lengthUnit) + "," + webSpacing + "," + profile.BotFlangeThickness.LengthFromSI(lengthUnit) +
                 ", 0, 0, 0, 0";
 
-            Engine.Reflection.Compute.RecordWarning(
-                "The corbel widths have been used from the top flange only"
-                );
+            Engine.Reflection.Compute.RecordWarning("MidasCivil does not support unequal corbel widths. Therefore the spacing of the webs " +
+                "have been calculated using the TopLeftCorbelWidth and TopRightCorbelWidth only.");
 
             return midasSectionProperty;
         }
@@ -303,12 +356,8 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         private static string CreateProfile(ZSectionProfile profile, string lengthUnit)
         {
-            string[] profilearray = profile.GetType().ToString().Split('.');
-            int profileindex = profilearray.Length;
+            Engine.Reflection.Compute.RecordError("ZSectionProfile not supported by the MidasCivil_Toolkit");
 
-            Engine.Reflection.Compute.RecordError(
-                profilearray[profileindex - 1] + " not supported in MidasCivil_Toolkit"
-                );
             return null;
         }
 
@@ -316,12 +365,8 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         private static string CreateProfile(FreeFormProfile profile, string lengthUnit)
         {
-            string[] profilearray = profile.GetType().ToString().Split('.');
-            int profileindex = profilearray.Length;
+            Engine.Reflection.Compute.RecordError("FreeFormProfile not supported by the MidasCivil_Toolkit");
 
-            Engine.Reflection.Compute.RecordError(
-                profilearray[profileindex - 1] + " not supported in MidasCivil_Toolkit"
-                );
             return null;
         }
 
@@ -329,12 +374,8 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         private static string CreateProfile(KiteProfile profile, string lengthUnit)
         {
-            string[] profilearray = profile.GetType().ToString().Split('.');
-            int profileindex = profilearray.Length;
+            Engine.Reflection.Compute.RecordError("KiteProfile not supported by the MidasCivil_Toolkit");
 
-            Engine.Reflection.Compute.RecordError(
-                profilearray[profileindex - 1] + " not supported in MidasCivil_Toolkit"
-                );
             return null;
         }
 
@@ -342,12 +383,8 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         private static string CreateProfile(GeneralisedTSectionProfile profile, string lengthUnit)
         {
-            string[] profilearray = profile.GetType().ToString().Split('.');
-            int profileindex = profilearray.Length;
+            Engine.Reflection.Compute.RecordError("GeneralisedTSectionProfile not supported by the MidasCivil_Toolkit");
 
-            Engine.Reflection.Compute.RecordError(
-                profilearray[profileindex - 1] + " not supported in MidasCivil_Toolkit"
-                );
             return null;
         }
 
@@ -357,12 +394,15 @@ namespace BH.Adapter.Adapters.MidasCivil
         {
             List<IProfile> profiles = new List<IProfile>(profile.Profiles.Values);
 
+            if (profiles.Count > 2)
+                Engine.Reflection.Compute.RecordWarning("MidasCivil only supports TaperedProfiles with a startProfile and endProfile, any intermediate profiles will be ignored.");
+
             List<string> startProfile = new List<string>(CreateProfile(profiles[0] as dynamic, lengthUnit).Split(','));
             List<string> endProfile = new List<string>(CreateProfile(profiles[profiles.Count - 1] as dynamic, lengthUnit).Split(','));
 
             startProfile.GetRange(2, startProfile.Count - 4);
 
-            return string.Join(",",startProfile.GetRange(2, startProfile.Count - 4)) + "," + string.Join(",", endProfile.GetRange(2, startProfile.Count - 4));
+            return string.Join(",", startProfile.GetRange(2, startProfile.Count - 4)) + "," + string.Join(",", endProfile.GetRange(2, startProfile.Count - 4));
         }
 
         /***************************************************/

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -59,7 +59,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) + 
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -81,7 +81,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -103,7 +103,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -125,7 +125,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -147,7 +147,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.AddRange(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         {
             List<string> midasSectionProperty = CreateSection(sectionProperty as dynamic, lengthUnit, sectionPropertyCharacterLimit);
 
-            return midasSectionProperty is null ? null : midasSectionProperty;
+            return midasSectionProperty == null ? null : midasSectionProperty;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/992
https://github.com/BHoM/BHoM_Engine/pull/1980
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #244 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EoQuT-hlPLVJpbYy2JulBl4B9ZZJxhUHUUDXFB40ncF1cA?e=RDh0aQ

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional Comments
- @StephennipBH can you push/pull a few `SectionProfile` types please as I have made changes to that code too.
- MidasCivil only accepts the start and end profile.