### PR TITLE
Remove use of CustomData and make use of new Fragment for AdapterId

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
@@ -20,9 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.Engine.Structure;
-
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,14 +45,14 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Bar bar in bars)
             {
-                if (new string(bar.Release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()) != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
+                if (new string(bar.Release.DescriptionOrName().Replace(",", "").Take(m_groupCharacterLimit).ToArray()) != "FixFix" && bar.FEAType == BarFEAType.TensionOnly)
                 {
                     Engine.Reflection.Compute.RecordError("Tension only elements cannot support bar releases in Midas");
                 }
 
-                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()) != "FixFix")
+                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Replace(",", "").Take(m_groupCharacterLimit).ToArray()) != "FixFix")
                 {
-                    AssignBarRelease(bar.CustomData[AdapterIdName].ToString(), new string(bar.Release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()), "FRAME-RLS");
+                    AssignBarRelease(bar.AdapterId<string>(typeof(MidasCivilId)), new string(bar.Release.DescriptionOrName().Replace(",", "").Take(m_groupCharacterLimit).ToArray()), "FRAME-RLS");
                 }
 
                 midasElements.Add(Adapters.MidasCivil.Convert.FromBar(bar));

--- a/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Node.cs
@@ -20,9 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Adapter;
 using BH.Engine.Structure;
+using BH.oM.Adapters.MidasCivil;
 using BH.oM.Structure.Elements;
-
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -49,11 +50,11 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (MidasCivilAdapter.GetStiffnessVectorModulus(node.Support) > 0)
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()), "SPRING");
+                        AssignProperty(node.AdapterId<string>(typeof(MidasCivilId)), new string(node.Support.DescriptionOrName().Replace(",", "").Take(m_groupCharacterLimit).ToArray()), "SPRING");
                     }
                     else
                     {
-                        AssignProperty(node.CustomData[AdapterIdName].ToString(), new string(node.Support.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()), "CONSTRAINT");
+                        AssignProperty(node.AdapterId<string>(typeof(MidasCivilId)), new string(node.Support.DescriptionOrName().Replace(",", "").Take(m_groupCharacterLimit).ToArray()), "CONSTRAINT");
                     }
 
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaTemperatureLoads.cs
@@ -25,7 +25,8 @@ using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
 using System.Collections.Generic;
 using System.IO;
-
+using BH.Engine.Adapter;
+using BH.oM.Adapters.MidasCivil;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -47,7 +48,7 @@ namespace BH.Adapter.MidasCivil
 
                 foreach (IAreaElement mesh in assignedElements)
                 {
-                    assignedFEMeshes.Add(mesh.CustomData[AdapterIdName].ToString());
+                    assignedFEMeshes.Add(mesh.AdapterId<string>(typeof(MidasCivilId)));
                 }
 
                 foreach (string assignedFEMesh in assignedFEMeshes)

--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
@@ -43,10 +45,10 @@ namespace BH.Adapter.MidasCivil
                 List<IAreaElement> assignedElements = areaUniformlyDistributedLoad.Objects.Elements;
 
                 List<string> assignedFEMeshes = new List<string>();
-				
+
                 foreach (IAreaElement mesh in assignedElements)
                 {
-                    assignedFEMeshes.Add(mesh.CustomData[AdapterIdName].ToString());
+                    assignedFEMeshes.Add(mesh.AdapterId<string>(typeof(MidasCivilId)));
                 }
 
                 List<double> loadVectors = new List<double> { areaUniformlyDistributedLoad.Pressure.X,
@@ -63,10 +65,10 @@ namespace BH.Adapter.MidasCivil
                     {
                         areaUniformlyDistributedLoad.Pressure = CreateSingleComponentVector(i, loadVectors[i]);
 
-                            foreach (string assignedFEMesh in assignedFEMeshes)
-                            {
-                                midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(areaUniformlyDistributedLoad, assignedFEMesh, m_forceUnit, m_lengthUnit));
-                            }
+                        foreach (string assignedFEMesh in assignedFEMeshes)
+                        {
+                            midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(areaUniformlyDistributedLoad, assignedFEMesh, m_forceUnit, m_lengthUnit));
+                        }
                     }
                 }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
@@ -20,8 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
 using BH.oM.Structure.Loads;
 using BH.oM.Geometry;
+using BH.Engine.Adapter;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,7 +46,7 @@ namespace BH.Adapter.MidasCivil
                 string barLoadPath = CreateSectionFile(barPointLoad.Loadcase.Name + "\\BEAMLOAD");
                 string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(barPointLoad);
 
-                List<string> assignedBars = barPointLoad.Objects.Elements.Select(x => x.CustomData[AdapterIdName].ToString()).ToList();
+                List<string> assignedBars = barPointLoad.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
 
                 List<double> loadVectors = new List<double> { barPointLoad.Force.X,
                                                               barPointLoad.Force.Y,

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarTemperatureLoads.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using System.Collections.Generic;
@@ -49,7 +51,7 @@ namespace BH.Adapter.MidasCivil
 
                 foreach (Bar bar in assignedElements)
                 {
-                    assignedBars.Add(bar.CustomData[AdapterIdName].ToString());
+                    assignedBars.Add(bar.AdapterId<string>(typeof(MidasCivilId)));
                 }
 
                 foreach (string assignedBar in assignedBars)

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Geometry;
 using System.IO;
@@ -44,7 +46,7 @@ namespace BH.Adapter.MidasCivil
                 string barLoadPath = CreateSectionFile(barUniformlyDistributedLoad.Loadcase.Name + "\\BEAMLOAD");
                 string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(barUniformlyDistributedLoad);
 
-                List<string> assignedBars = barUniformlyDistributedLoad.Objects.Elements.Select(x => x.CustomData[AdapterIdName].ToString()).ToList();
+                List<string> assignedBars = barUniformlyDistributedLoad.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
 
                 List<double> loadVectors = new List<double> { barUniformlyDistributedLoad.Force.X,
                                                               barUniformlyDistributedLoad.Force.Y,

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Geometry;
 using System.IO;
@@ -44,7 +46,7 @@ namespace BH.Adapter.MidasCivil
                 string barLoadPath = CreateSectionFile(barVaryingDistributedLoad.Loadcase.Name + "\\BEAMLOAD");
                 string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(barVaryingDistributedLoad);
 
-                List<string> assignedBars = barVaryingDistributedLoad.Objects.Elements.Select(x => x.CustomData[AdapterIdName].ToString()).ToList();
+                List<string> assignedBars = barVaryingDistributedLoad.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
 
                 List<double> startLoadVectors = new List<double> { barVaryingDistributedLoad.ForceA.X,
                                                               barVaryingDistributedLoad.ForceA.Y,

--- a/MidasCivil_Adapter/CRUD/Create/Loads/LoadCombinations.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/LoadCombinations.cs
@@ -20,7 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
 using BH.oM.Structure.Loads;
+using BH.Engine.Adapter;
 using System.Collections.Generic;
 using System.IO;
 
@@ -39,7 +41,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (LoadCombination loadCombination in loadCombinations)
             {
-                loadCombination.CustomData[AdapterIdName] = loadCombination.Name;
+                loadCombination.SetAdapterId(typeof(MidasCivilId), loadCombination.Name);
                 midasLoadCombinations.AddRange(Adapters.MidasCivil.Convert.FromLoadCombination(loadCombination, m_midasCivilVersion));
             }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Adapter;
+using BH.oM.Adapters.MidasCivil;
 using BH.oM.Structure.Loads;
 using System.Collections.Generic;
 using System.IO;
@@ -40,7 +42,7 @@ namespace BH.Adapter.MidasCivil
 
             foreach (Loadcase loadcase in loadcases)
             {
-                loadcase.CustomData[AdapterIdName] = loadcase.Name;
+                loadcase.SetAdapterId(typeof(MidasCivilId), loadcase.Name);
                 Directory.CreateDirectory(m_directory + "\\TextFiles\\" + loadcase.Name);
                 midasLoadCases.Add(Adapters.MidasCivil.Convert.FromLoadcase(loadcase));
             }

--- a/MidasCivil_Adapter/CRUD/Create/Loads/PointForce.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/PointForce.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using System.IO;
 using System.Collections.Generic;
@@ -43,7 +45,7 @@ namespace BH.Adapter.MidasCivil
                 string PointLoadPath = CreateSectionFile(PointLoad.Loadcase.Name + "\\CONLOAD");
                 string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(PointLoad);
 
-                List<string> assignedNodes = PointLoad.Objects.Elements.Select(x => x.CustomData[AdapterIdName].ToString()).ToList();
+                List<string> assignedNodes = PointLoad.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
 
                 foreach (string assignedNode in assignedNodes)
                 {

--- a/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/Bars.cs
@@ -22,6 +22,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
@@ -55,17 +57,17 @@ namespace BH.Adapter.MidasCivil
 
             IEnumerable<Node> bhomNodesList = ReadNodes();
             Dictionary<string, Node> bhomNodes = bhomNodesList.ToDictionary(
-                x => x.CustomData[AdapterIdName].ToString());
+                x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             IEnumerable<BarRelease> bhomBarReleaseList = ReadBarReleases();
-            Dictionary<string, BarRelease> bhomBarReleases = bhomBarReleaseList.ToDictionary(x => x.CustomData[AdapterIdName].ToString());
+            Dictionary<string, BarRelease> bhomBarReleases = bhomBarReleaseList.ToDictionary(x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             IEnumerable<ISectionProperty> bhomSectionPropertyList = ReadSectionProperties();
             Dictionary<string, ISectionProperty> bhomSectionProperties = bhomSectionPropertyList.ToDictionary(
-                x => x.CustomData[AdapterIdName].ToString());
+                x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             IEnumerable<IMaterialFragment> bhomMaterialList = ReadMaterials();
-            Dictionary<string, IMaterialFragment> bhomMaterials = bhomMaterialList.ToDictionary(x => x.CustomData[AdapterIdName].ToString());
+            Dictionary<string, IMaterialFragment> bhomMaterials = bhomMaterialList.ToDictionary(x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             Dictionary<string, List<int>> barReleaseAssignments = GetBarReleaseAssignments("FRAME-RLS", "barRelease");
 
@@ -80,7 +82,7 @@ namespace BH.Adapter.MidasCivil
             foreach (string bar in barText)
             {
                 Bar bhomBar = Adapters.MidasCivil.Convert.ToBar(bar, bhomNodes, materialSections, bhomBarReleases, barReleaseAssignments);
-                int bhomID = System.Convert.ToInt32(bhomBar.CustomData[AdapterIdName]);
+                int bhomID = bhomBar.AdapterId<int>(typeof(MidasCivilId));
                 bhomBar.Tags = GetGroupAssignments(elementGroups, bhomID);
                 bhomBars.Add(bhomBar);
             }

--- a/MidasCivil_Adapter/CRUD/Read/Elements/FEMeshes.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/FEMeshes.cs
@@ -22,6 +22,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SurfaceProperties;
@@ -44,19 +46,19 @@ namespace BH.Adapter.MidasCivil
 
             IEnumerable<Node> bhomNodesList = ReadNodes();
             Dictionary<string, Node> bhomNodes = bhomNodesList.ToDictionary(
-                x => x.CustomData[AdapterIdName].ToString());
+                x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             IEnumerable<ISurfaceProperty> bhomSurfacePropertiesList = ReadSurfaceProperties();
             Dictionary<string, ISurfaceProperty> bhomSuraceProperties = bhomSurfacePropertiesList.ToDictionary(
-                x => x.CustomData[AdapterIdName].ToString());
+                x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             IEnumerable<IMaterialFragment> bhomMaterialList = ReadMaterials();
-            Dictionary<string, IMaterialFragment> bhomMaterials = bhomMaterialList.ToDictionary(x => x.CustomData[AdapterIdName].ToString());
+            Dictionary<string, IMaterialFragment> bhomMaterials = bhomMaterialList.ToDictionary(x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             foreach (string mesh in meshText)
             {
                 FEMesh bhomMesh = Adapters.MidasCivil.Convert.ToFEMesh(mesh, bhomNodes, bhomSuraceProperties, bhomMaterials);
-                int bhomID = System.Convert.ToInt32(bhomMesh.CustomData[AdapterIdName]);
+                int bhomID = bhomMesh.AdapterId<int>(typeof(MidasCivilId));
                 bhomMesh.Tags = GetGroupAssignments(elementGroups, bhomID);
                 bhomMeshes.Add(bhomMesh);
             }

--- a/MidasCivil_Adapter/CRUD/Read/Elements/Nodes.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/Nodes.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using System.Collections.Generic;
@@ -53,7 +55,7 @@ namespace BH.Adapter.MidasCivil
             foreach (string node in nodesText)
             {
                 Node bhomNode = Adapters.MidasCivil.Convert.ToNode(node, supports, supportAssignments, springAssignments, m_lengthUnit);
-                int bhomID = System.Convert.ToInt32(bhomNode.CustomData[AdapterIdName]);
+                int bhomID = bhomNode.AdapterId<int>(typeof(MidasCivilId));
                 bhomNode.Tags = GetGroupAssignments(nodeGroups, bhomID);
                 bhomNodes.Add(bhomNode);
             }

--- a/MidasCivil_Adapter/CRUD/Read/Elements/RigidLinks.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Elements/RigidLinks.cs
@@ -20,8 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
-using BH.oM.Structure.Constraints;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -40,7 +41,7 @@ namespace BH.Adapter.MidasCivil
 
             List<string> linkText = GetSectionText("RIGIDLINK");
             List<Node> nodes = ReadNodes();
-            Dictionary<string, Node> nodeDictionary = nodes.ToDictionary(x => x.CustomData[AdapterIdName].ToString());
+            Dictionary<string, Node> nodeDictionary = nodes.ToDictionary(x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             int count = 0;
 

--- a/MidasCivil_Adapter/CRUD/Read/Loads/AreaTemperatureLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/AreaTemperatureLoad.cs
@@ -24,6 +24,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 
@@ -65,7 +67,7 @@ namespace BH.Adapter.MidasCivil
                     {
                         List<FEMesh> bhomMeshes = ReadFEMeshes();
                         Dictionary<string, FEMesh> FEMeshDictionary = bhomMeshes.ToDictionary(
-                                                                    x => x.CustomData[AdapterIdName].ToString());
+                                                                    x => x.AdapterId<string>(typeof(MidasCivilId)));
                         List<string> distinctFEMeshLoads = feMeshComparison.Distinct().ToList();
 
                         foreach (string distinctFEMeshLoad in distinctFEMeshLoads)

--- a/MidasCivil_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoad.cs
@@ -24,6 +24,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 
@@ -65,7 +67,7 @@ namespace BH.Adapter.MidasCivil
                     {
                         List<FEMesh> bhomMeshes = ReadFEMeshes();
                         Dictionary<string, FEMesh> FEMeshDictionary = bhomMeshes.ToDictionary(
-                                                                    x => x.CustomData[AdapterIdName].ToString());
+                                                                    x => x.AdapterId<string>(typeof(MidasCivilId)));
                         List<string> distinctFEMeshLoads = feMeshComparison.Distinct().ToList();
 
                         foreach (string distinctFEMeshLoad in distinctFEMeshLoads)

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarPointLoads.cs
@@ -22,6 +22,8 @@
 
 using System;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using System.Linq;
@@ -94,7 +96,7 @@ namespace BH.Adapter.MidasCivil
                     {
                         List<Bar> bhomBars = ReadBars();
                         Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
-                                                                    x => x.CustomData[AdapterIdName].ToString());
+                                                                    x => x.AdapterId<string>(typeof(MidasCivilId)));
 
                         List<string> distinctBarLoads = barComparison.Distinct().ToList();
 
@@ -107,7 +109,7 @@ namespace BH.Adapter.MidasCivil
                             List<string> matchingBars = new List<string>();
                             indexMatches.ForEach(x => matchingBars.Add(loadedBars[x]));
 
-                            BarPointLoad bhomBarPointLoad = Adapters.MidasCivil.Convert.ToBarPointLoad(distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary,1,m_forceUnit, m_lengthUnit);
+                            BarPointLoad bhomBarPointLoad = Adapters.MidasCivil.Convert.ToBarPointLoad(distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, 1, m_forceUnit, m_lengthUnit);
                             bhomBarPointLoads.Add(bhomBarPointLoad);
 
                             if (String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarTemperatureLoads.cs
@@ -24,6 +24,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 
@@ -69,7 +71,7 @@ namespace BH.Adapter.MidasCivil
                     {
                         List<Bar> bhomBars = ReadBars();
                         Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
-                                                                    x => x.CustomData[AdapterIdName].ToString());
+                                                                    x => x.AdapterId<string>(typeof(MidasCivilId)));
                         List<string> distinctBarLoads = barComparison.Distinct().ToList();
 
                         foreach (string distinctBarLoad in distinctBarLoads)

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoad.cs
@@ -22,6 +22,8 @@
 
 using System;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using System.Linq;
@@ -86,7 +88,7 @@ namespace BH.Adapter.MidasCivil
                     {
                         List<Bar> bhomBars = ReadBars();
                         Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
-                                                                    x => x.CustomData[AdapterIdName].ToString());
+                                                                    x => x.AdapterId<string>(typeof(MidasCivilId)));
                         List<string> distinctBarLoads = barComparison.Distinct().ToList();
 
                         foreach (string distinctBarLoad in distinctBarLoads)
@@ -103,7 +105,7 @@ namespace BH.Adapter.MidasCivil
                                     distinctBarLoad, matchingBars, loadcase, loadcaseDictionary, barDictionary, i, m_forceUnit, m_lengthUnit);
                             bhomBarUniformlyDistributedLoads.Add(bhomBarUniformlyDistributedLoad);
 
-                            if(String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))
+                            if (String.IsNullOrWhiteSpace(distinctBarLoad.Split(',').ToList()[17]))
                             {
                                 i = i + 1;
                             }

--- a/MidasCivil_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
@@ -22,6 +22,8 @@
 
 using System;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using System.Linq;
@@ -75,7 +77,7 @@ namespace BH.Adapter.MidasCivil
                     {
                         List<Bar> bhomBars = ReadBars();
                         Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
-                                                                    x => x.CustomData[AdapterIdName].ToString());
+                                                                    x => x.AdapterId<string>(typeof(MidasCivilId)));
 
                         List<string> distinctBarLoads = barComparison.Distinct().ToList();
 

--- a/MidasCivil_Adapter/CRUD/Read/Loads/LoadCombinations.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/LoadCombinations.cs
@@ -23,6 +23,8 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 
 namespace BH.Adapter.MidasCivil
@@ -40,7 +42,7 @@ namespace BH.Adapter.MidasCivil
 
             IEnumerable<Loadcase> bhomLoadCases = ReadLoadcases();
             Dictionary<string, Loadcase> bhomLoadCaseDictionary = bhomLoadCases.ToDictionary(
-                x => x.CustomData[AdapterIdName].ToString());
+                x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             for (int i = 0; i < loadCombinationText.Count; i += 2)
             {

--- a/MidasCivil_Adapter/CRUD/Read/Loads/PointForces.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/PointForces.cs
@@ -23,6 +23,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using System.IO;
@@ -56,7 +58,7 @@ namespace BH.Adapter.MidasCivil
                 {
                     List<Node> bhomNodes = ReadNodes();
                     Dictionary<string, Node> nodeDictionary = bhomNodes.ToDictionary(
-                                                                x => x.CustomData[AdapterIdName].ToString());
+                                                                x => x.AdapterId<string>(typeof(MidasCivilId)));
 
                     List<string> PointLoadComparison = new List<string>();
                     List<string> PointLoadNodes = new List<string>();

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -20,7 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Spatial.ShapeProfiles;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.SectionProperties;
 using System;
 using System.Collections.Generic;
@@ -61,7 +62,7 @@ namespace BH.Adapter.MidasCivil
                         split[12].Trim(), m_lengthUnit);
 
                     bhomSectionProperty.Name = split[2].Trim();
-                    bhomSectionProperty.CustomData[AdapterIdName] = split[0].Trim();
+                    bhomSectionProperty.SetAdapterId(typeof(MidasCivilId), split[0].Trim());
 
                     i = i + 3;
                 }
@@ -80,7 +81,7 @@ namespace BH.Adapter.MidasCivil
                             split[12].Trim(), m_lengthUnit);
 
                         bhomSectionProperty.Name = split[2].Trim();
-                        bhomSectionProperty.CustomData[AdapterIdName] = split[0].Trim();
+                        bhomSectionProperty.SetAdapterId(typeof(MidasCivilId), split[0].Trim());
                     }
                 }
                 else if (type == "TAPERED")
@@ -92,7 +93,7 @@ namespace BH.Adapter.MidasCivil
 
                     bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(profiles, "TAPERED" + "-" + shape + "-" + interpolationOrder, m_lengthUnit);
 
-                    bhomSectionProperty.CustomData[AdapterIdName] = split[0].Trim();
+                    bhomSectionProperty.SetAdapterId(typeof(MidasCivilId), split[0].Trim());
                     bhomSectionProperty.Name = split[2].Trim();
 
                     i = i + 1;

--- a/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -24,6 +24,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Base;
 using BH.oM.Data.Requests;
 using BH.oM.Structure.Loads;
@@ -63,13 +65,13 @@ namespace BH.Adapter.MidasCivil
                     foreach (object o in ids)
                     {
                         int id;
-                        object idObj;
                         if (int.TryParse(o.ToString(), out id))
                         {
                             idsOut.Add(id);
                         }
-                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue(AdapterIdName, out idObj) && int.TryParse(idObj.ToString(), out id))
-                            idsOut.Add(id);
+                        else if (o is IBHoMObject && (o as IBHoMObject).HasAdapterIdFragment(typeof(MidasCivilId)))
+                            int.TryParse((o as IBHoMObject).AdapterId<string>(typeof(MidasCivilId)), out id);
+                        idsOut.Add(id);
                     }
                     return idsOut;
                 }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToBar.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToBar.cs
@@ -20,9 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
-using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SectionProperties;
 using System.Collections.Generic;
 using System.Linq;
@@ -94,7 +95,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             double orientationAngle = double.Parse(delimitted[6].Trim());
 
             Bar bhomBar = Engine.Structure.Create.Bar(startNode, endNode, sectionProperty, orientationAngle, barRelease, feaType);
-            bhomBar.CustomData[AdapterIdName] = bhomID;
+            bhomBar.SetAdapterId(typeof(MidasCivilId), bhomID);
 
             return bhomBar;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToFEMesh.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToFEMesh.cs
@@ -20,10 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.SurfaceProperties;
-using BH.oM.Geometry;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -90,7 +91,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 Property = bhomSurfaceProperty
             };
 
-            bhomFEMesh.CustomData[AdapterIdName] = delimitted[0].Trim();
+            bhomFEMesh.SetAdapterId(typeof(MidasCivilId), delimitted[0].Trim());
 
             return bhomFEMesh;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToNode.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToNode.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Adapter;
+using BH.oM.Adapters.MidasCivil;
 using BH.oM.Geometry;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.Elements;
@@ -48,8 +50,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 );
 
-            bhomNode.CustomData[AdapterIdName] = delimitted[0].Trim();
-            int bhomID = System.Convert.ToInt32(bhomNode.CustomData[AdapterIdName]);
+            bhomNode.SetAdapterId(typeof(MidasCivilId), delimitted[0].Trim());
+            int bhomID = bhomNode.AdapterId<int>(typeof(MidasCivilId));
 
             string supportName = "";
 

--- a/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
@@ -26,6 +26,8 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Geometry;
 using System.Collections.Generic;
 using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.MidasCivil;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -51,8 +53,8 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             List<Panel> panels = Engine.Structure.Create.Panel(polylines.Cast<ICurve>().ToList());
 
-            if (mesh.CustomData.ContainsValue(AdapterIdName))
-                panels[0].CustomData[AdapterIdName] = mesh.CustomData[AdapterIdName];
+            if (mesh.HasAdapterIdFragment(typeof(MidasCivilId)))
+                panels[0].SetAdapterId(typeof(MidasCivilId), mesh.AdapterId<int>(typeof(MidasCivilId)));
 
             return panels[0];
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToRigidLink.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToRigidLink.cs
@@ -22,6 +22,8 @@
 
 using System.Linq;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.Adapter.MidasCivil;
@@ -76,7 +78,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             RigidLink bhomRigidLink = Engine.Structure.Create.RigidLink(primaryNode, secondaryNodes, constraint);
             bhomRigidLink.Name = name;
-            bhomRigidLink.CustomData[AdapterIdName] = name;
+            bhomRigidLink.SetAdapterId(typeof(MidasCivilId), name);
 
             return bhomRigidLink;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToAreaTemperatureLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToAreaTemperatureLoad.cs
@@ -21,6 +21,8 @@
  */
 
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 
@@ -69,7 +71,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 AreaTemperatureLoad bhomAreaUniformlyDistributedLoad = Engine.Structure.Create.AreaTemperatureLoad(
                     bhomLoadcase, temperature.DeltaTemperatureToSI(temperatureUnit),
                     bhomAssociatedFEMeshes, LoadAxis.Global, false, name);
-                bhomAreaUniformlyDistributedLoad.CustomData[AdapterIdName] = bhomAreaUniformlyDistributedLoad.Name;
+                bhomAreaUniformlyDistributedLoad.SetAdapterId(typeof(MidasCivilId), bhomAreaUniformlyDistributedLoad.Name);
                 return bhomAreaUniformlyDistributedLoad;
             }
             else

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToAreaUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToAreaUniformlyDistributedLoad.cs
@@ -21,6 +21,8 @@
  */
 
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
@@ -34,7 +36,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /***************************************************/
 
         public static AreaUniformlyDistributedLoad ToAreaUniformlyDistributedLoad(string areaUniformlyDistributedLoad, List<string> associatedFEMeshes,
-            string loadcase, Dictionary<string, Loadcase> loadcaseDictionary, Dictionary<string, FEMesh> femeshDictionary, 
+            string loadcase, Dictionary<string, Loadcase> loadcaseDictionary, Dictionary<string, FEMesh> femeshDictionary,
             int count, string forceUnit, string lengthUnit)
         {
             string[] delimitted = areaUniformlyDistributedLoad.Split(',');
@@ -104,8 +106,8 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
 
             AreaUniformlyDistributedLoad bhomAreaUniformlyDistributedLoad = Engine.Structure.Create.AreaUniformlyDistributedLoad(
-                bhomLoadcase, loadVector,bhomAssociatedFEMeshes, axis, loadProjection, name);
-            bhomAreaUniformlyDistributedLoad.CustomData[AdapterIdName] = bhomAreaUniformlyDistributedLoad.Name;
+                bhomLoadcase, loadVector, bhomAssociatedFEMeshes, axis, loadProjection, name);
+            bhomAreaUniformlyDistributedLoad.SetAdapterId(typeof(MidasCivilId), bhomAreaUniformlyDistributedLoad.Name);
 
             return bhomAreaUniformlyDistributedLoad;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarPointLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarPointLoad.cs
@@ -21,6 +21,8 @@
  */
 
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
@@ -113,12 +115,12 @@ namespace BH.Adapter.Adapters.MidasCivil
             if (loadType == "CONLOAD")
             {
                 bhomBarPointLoad = Engine.Structure.Create.BarPointLoad(bhomLoadcase, distA, bhomAssociatedBars, loadVector, null, axis, name);
-                bhomBarPointLoad.CustomData[AdapterIdName] = bhomBarPointLoad.Name;
+                bhomBarPointLoad.SetAdapterId(typeof(MidasCivilId), bhomBarPointLoad.Name);
             }
             else
             {
                 bhomBarPointLoad = Engine.Structure.Create.BarPointLoad(bhomLoadcase, distA, bhomAssociatedBars, null, loadVector, axis, name);
-                bhomBarPointLoad.CustomData[AdapterIdName] = bhomBarPointLoad.Name;
+                bhomBarPointLoad.SetAdapterId(typeof(MidasCivilId), bhomBarPointLoad.Name);
             }
 
             return bhomBarPointLoad;

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarTemperatureLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarTemperatureLoad.cs
@@ -21,6 +21,8 @@
  */
 
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 
@@ -68,7 +70,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 BarTemperatureLoad bhombarUniformlyDistributedLoad = Engine.Structure.Create.BarTemperatureLoad(
                     bhomLoadcase, temperature, bhomAssociatedBars, LoadAxis.Global, false, name);
-                bhombarUniformlyDistributedLoad.CustomData[AdapterIdName] = bhombarUniformlyDistributedLoad.Name;
+                bhombarUniformlyDistributedLoad.SetAdapterId(typeof(MidasCivilId), bhombarUniformlyDistributedLoad.Name);
                 return bhombarUniformlyDistributedLoad;
             }
             else

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarUniformlyDistributedLoad.cs
@@ -21,6 +21,8 @@
  */
 
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
@@ -119,13 +121,13 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 bhomBarUniformlyDistributedLoad = Engine.Structure.Create.BarUniformlyDistributedLoad(
                     bhomLoadcase, bhomAssociatedBars, loadVector, null, axis, loadProjection, name);
-                bhomBarUniformlyDistributedLoad.CustomData[AdapterIdName] = bhomBarUniformlyDistributedLoad.Name;
+                bhomBarUniformlyDistributedLoad.SetAdapterId(typeof(MidasCivilId), bhomBarUniformlyDistributedLoad.Name);
             }
             else
             {
                 bhomBarUniformlyDistributedLoad = Engine.Structure.Create.BarUniformlyDistributedLoad(
                     bhomLoadcase, bhomAssociatedBars, null, loadVector, axis, loadProjection, name);
-                bhomBarUniformlyDistributedLoad.CustomData[AdapterIdName] = bhomBarUniformlyDistributedLoad.Name;
+                bhomBarUniformlyDistributedLoad.SetAdapterId(typeof(MidasCivilId), bhomBarUniformlyDistributedLoad.Name);
             }
 
             return bhomBarUniformlyDistributedLoad;

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarVaryingDistributedLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToBarVaryingDistributedLoad.cs
@@ -21,6 +21,8 @@
  */
 
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
@@ -142,13 +144,13 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 bhomBarVaryingDistributedLoad = Engine.Structure.Create.BarVaryingDistributedLoad(
                     bhomLoadcase, bhomAssociatedBars, distA, startLoadVector, null, distB, endLoadVector, null, axis, loadProjection, name);
-                bhomBarVaryingDistributedLoad.CustomData[AdapterIdName] = bhomBarVaryingDistributedLoad.Name;
+                bhomBarVaryingDistributedLoad.SetAdapterId(typeof(MidasCivilId), bhomBarVaryingDistributedLoad.Name);
             }
             else
             {
                 bhomBarVaryingDistributedLoad = Engine.Structure.Create.BarVaryingDistributedLoad(
                     bhomLoadcase, bhomAssociatedBars, distA, null, startLoadVector, distB, null, endLoadVector, axis, loadProjection, name);
-                bhomBarVaryingDistributedLoad.CustomData[AdapterIdName] = bhomBarVaryingDistributedLoad.Name;
+                bhomBarVaryingDistributedLoad.SetAdapterId(typeof(MidasCivilId), bhomBarVaryingDistributedLoad.Name);
             }
 
             return bhomBarVaryingDistributedLoad;

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -20,10 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
-using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
 using BH.oM.Base;
 
@@ -35,7 +35,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static GravityLoad ToGravityLoad(List<BHoMObject> objects, string gravityLoad, string loadcase, 
+        public static GravityLoad ToGravityLoad(List<BHoMObject> objects, string gravityLoad, string loadcase,
             Dictionary<string, Loadcase> loadcaseDictionary, int count)
         {
             string[] delimitted = gravityLoad.Split(',');
@@ -61,7 +61,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
 
             GravityLoad bhomGravityLoad = Engine.Structure.Create.GravityLoad(bhomLoadcase, direction, objects, name);
-            bhomGravityLoad.CustomData[AdapterIdName] = bhomGravityLoad.Name;
+            bhomGravityLoad.SetAdapterId(typeof(MidasCivilId), bhomGravityLoad.Name);
 
             return bhomGravityLoad;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToLoadCombination.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToLoadCombination.cs
@@ -21,6 +21,8 @@
  */
 
 using System;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Loads;
@@ -53,7 +55,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             int number = 0;
 
             LoadCombination bhomLoadCombination = BH.Engine.Structure.Create.LoadCombination(name, number, associatedLoadcases, loadFactors);
-            bhomLoadCombination.CustomData[AdapterIdName] = name;
+            bhomLoadCombination.SetAdapterId(typeof(MidasCivilId), name);
 
             return bhomLoadCombination;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToLoadcase.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToLoadcase.cs
@@ -21,6 +21,8 @@
  */
 
 using System;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using System.Collections.Generic;
 using BH.oM.Structure.Loads;
 using System.Linq;
@@ -46,7 +48,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 Number = 0,
             };
 
-            bhomLoadCase.CustomData[AdapterIdName] = delimitted[0].Trim();
+            bhomLoadCase.SetAdapterId(typeof(MidasCivilId), delimitted[0].Trim());
 
             return bhomLoadCase;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToPointForce.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToPointForce.cs
@@ -21,6 +21,8 @@
  */
 
 using System;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using System.Collections.Generic;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
@@ -80,7 +82,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             IEnumerable<Node> nodes = bhomAssociatedNodes;
 
             PointLoad bhomPointLoad = Engine.Structure.Create.PointLoad(bhomLoadcase, nodes, forceVector, momentVector, LoadAxis.Global, name);
-            bhomPointLoad.CustomData[AdapterIdName] = bhomPointLoad.Name;
+            bhomPointLoad.SetAdapterId(typeof(MidasCivilId), bhomPointLoad.Name);
 
             return bhomPointLoad;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToBarRelease.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToBarRelease.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Constraints;
 using System.Collections.Generic;
 using System.Linq;
@@ -65,7 +67,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
 
             BarRelease bhomBarRelease = Engine.Structure.Create.BarRelease(startConstraint, endConstraint, releaseName);
-            bhomBarRelease.CustomData[AdapterIdName] = bhomBarRelease.Name;
+            bhomBarRelease.SetAdapterId(typeof(MidasCivilId), bhomBarRelease.Name);
 
             return bhomBarRelease;
         }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Constraints;
 using System.Collections.Generic;
 using System.Linq;
@@ -143,7 +145,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
 
             Constraint6DOF bhomConstraint6DOF = Engine.Structure.Create.Constraint6DOF(supportName, fixity, stiffness);
-            bhomConstraint6DOF.CustomData[AdapterIdName] = supportName;
+            bhomConstraint6DOF.SetAdapterId(typeof(MidasCivilId), supportName);
 
             return bhomConstraint6DOF;
 

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToMaterials.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToMaterials.cs
@@ -19,6 +19,9 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
+
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry;
 using System.Linq;
@@ -153,7 +156,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
             }
 
-            bhomMaterial.CustomData[AdapterIdName] = delimited[0].Trim();
+            bhomMaterial.SetAdapterId(typeof(MidasCivilId), delimited[0].Trim());
             return bhomMaterial;
         }
 

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.SurfaceProperties;
 
 namespace BH.Adapter.Adapters.MidasCivil
@@ -54,7 +56,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     break;
             }
 
-            constantThickness.CustomData[AdapterIdName] = split[0].Trim();
+            constantThickness.SetAdapterId(typeof(MidasCivilId), split[0].Trim());
 
             if (split[5].Trim() == "YES")
                 Engine.Reflection.Compute.RecordWarning("SurfaceProperty objects do not have offsets implemented so this information will be lost");

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromBar.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromBar.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using System.Collections.Generic;
 
@@ -53,30 +55,30 @@ namespace BH.Adapter.Adapters.MidasCivil
                     break;
             }
 
-            string startNodeID = bar.StartNode.CustomData[AdapterIdName].ToString();
-            string endNodeID = bar.EndNode.CustomData[AdapterIdName].ToString();
+            string startNodeID = bar.StartNode.AdapterId<string>(typeof(MidasCivilId));
+            string endNodeID = bar.EndNode.AdapterId<string>(typeof(MidasCivilId));
             string materialID = "1";
             string sectionID = "1";
 
             if (bar.SectionProperty != null)
             {
-                sectionID = bar.SectionProperty.CustomData[AdapterIdName].ToString();
+                sectionID = bar.SectionProperty.AdapterId<string>(typeof(MidasCivilId));
                 if (bar.SectionProperty.Material != null)
                 {
-                    materialID = bar.SectionProperty.Material.CustomData[AdapterIdName].ToString();
+                    materialID = bar.SectionProperty.Material.AdapterId<string>(typeof(MidasCivilId));
                 }
             }
 
             if (bar.FEAType == BarFEAType.Axial || bar.FEAType == BarFEAType.Flexural)
             {
-                midasElement = (bar.CustomData[AdapterIdName].ToString() + "," + feaType +
+                midasElement = (bar.AdapterId<string>(typeof(MidasCivilId)) + "," + feaType +
                                       "," + materialID + "," + sectionID + "," +
                                       startNodeID + "," + endNodeID + "," +
-                                      (bar.OrientationAngle*180/System.Math.PI).ToString() + ",0,0");
+                                      (bar.OrientationAngle * 180 / System.Math.PI).ToString() + ",0,0");
             }
             else
             {
-                midasElement = (bar.CustomData[AdapterIdName].ToString() + "," + feaType +
+                midasElement = (bar.AdapterId<string>(typeof(MidasCivilId)) + "," + feaType +
                                   "," + materialID + "," + sectionID + "," +
                                   startNodeID + "," + endNodeID + "," +
                                   (bar.OrientationAngle * 180 / System.Math.PI).ToString() + ",1,0,0,NO");

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromFEMesh.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromFEMesh.cs
@@ -20,10 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using System.Collections.Generic;
-using BH.oM.Structure.MaterialFragments;
-using BH.Engine.Structure;
 namespace BH.Adapter.Adapters.MidasCivil
 {
     public static partial class Convert
@@ -41,11 +41,11 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             if (!(feMesh.Property == null))
             {
-                sectionPropertyId = feMesh.Property.CustomData[AdapterIdName].ToString();
+                sectionPropertyId = feMesh.Property.AdapterId<string>(typeof(MidasCivilId));
 
                 if (!(feMesh.Property.Material == null))
                 {
-                    materialId = feMesh.Property.Material.CustomData[AdapterIdName].ToString();
+                    materialId = feMesh.Property.Material.AdapterId<string>(typeof(MidasCivilId));
                 }
             }
             if (feMesh.Nodes.Count > 4)
@@ -55,22 +55,22 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             if (feMesh.Nodes.Count == 4)
             {
-                midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
+                midasElement = (feMesh.AdapterId<string>(typeof(MidasCivilId)) + ",PLATE," +
                 materialId + "," +
                 sectionPropertyId + "," +
-              feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
-              feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
-              feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + "," +
-              feMesh.Nodes[nodeIndices[3]].CustomData[AdapterIdName].ToString() + ",1,0");
+              feMesh.Nodes[nodeIndices[0]].AdapterId<string>(typeof(MidasCivilId)) + "," +
+              feMesh.Nodes[nodeIndices[1]].AdapterId<string>(typeof(MidasCivilId)) + "," +
+              feMesh.Nodes[nodeIndices[2]].AdapterId<string>(typeof(MidasCivilId)) + "," +
+              feMesh.Nodes[nodeIndices[3]].AdapterId<string>(typeof(MidasCivilId)) + ",1,0");
             }
             else
             {
-                midasElement = (feMesh.CustomData[AdapterIdName].ToString() + ",PLATE," +
+                midasElement = (feMesh.AdapterId<string>(typeof(MidasCivilId)) + ",PLATE," +
                 materialId + "," +
                 sectionPropertyId + "," +
-             feMesh.Nodes[nodeIndices[0]].CustomData[AdapterIdName].ToString() + "," +
-             feMesh.Nodes[nodeIndices[1]].CustomData[AdapterIdName].ToString() + "," +
-             feMesh.Nodes[nodeIndices[2]].CustomData[AdapterIdName].ToString() + ",0,1,0");
+             feMesh.Nodes[nodeIndices[0]].AdapterId<string>(typeof(MidasCivilId)) + "," +
+             feMesh.Nodes[nodeIndices[1]].AdapterId<string>(typeof(MidasCivilId)) + "," +
+             feMesh.Nodes[nodeIndices[2]].AdapterId<string>(typeof(MidasCivilId)) + ",0,1,0");
             }
             return midasElement;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromNode.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromNode.cs
@@ -20,8 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
-using BH.Engine.Units;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -35,7 +36,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         {
             string midasNode =
                 (
-                    node.CustomData[AdapterIdName].ToString() + "," +
+                    node.AdapterId<string>(typeof(MidasCivilId)) + "," +
                     node.Position.X.LengthFromSI(lengthUnit).ToString() + "," +
                     node.Position.Y.LengthFromSI(lengthUnit).ToString() + "," +
                     node.Position.Z.LengthFromSI(lengthUnit).ToString()

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromRigidLink.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromRigidLink.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 
 namespace BH.Adapter.Adapters.MidasCivil
@@ -34,12 +36,12 @@ namespace BH.Adapter.Adapters.MidasCivil
         {
             string midasLink = "";
 
-            string primaryId = link.PrimaryNode.CustomData[AdapterIdName].ToString();
+            string primaryId = link.PrimaryNode.AdapterId<string>(typeof(MidasCivilId));
             string secondaryId = "";
 
             foreach (Node secondaryNode in link.SecondaryNodes)
             {
-                secondaryId = secondaryId + " " + secondaryNode.CustomData[AdapterIdName].ToString();
+                secondaryId = secondaryId + " " + secondaryNode.AdapterId<string>(typeof(MidasCivilId));
             }
 
             string fixity = BoolToFixity(link.Constraint.XtoX) +

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromMaterial.cs
@@ -20,7 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Structure;
 using System.Linq;
@@ -55,8 +56,8 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 IIsotropic isotropic = material as IIsotropic;
                 midasMaterial = (
-                    isotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    new string(isotropic.DescriptionOrName().Replace(",","").Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
+                    isotropic.AdapterId<string>(typeof(MidasCivilId)) + "," + type + "," +
+                    new string(isotropic.DescriptionOrName().Replace(",", "").Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
                     isotropic.DampingRatio + ",2," + isotropic.YoungsModulus.PressureFromSI(forceUnit, lengthUnit) + "," +
                     isotropic.PoissonsRatio + "," + isotropic.ThermalExpansionCoeff.InverseDeltaTemperatureFromSI(temperatureUnit) + "," +
                     isotropic.Density.DensityFromSI(forceUnit, lengthUnit) * 9.806 + "," + isotropic.Density.DensityFromSI(forceUnit, lengthUnit)
@@ -66,17 +67,17 @@ namespace BH.Adapter.Adapters.MidasCivil
             {
                 IOrthotropic iorthotropic = material as IOrthotropic;
                 midasMaterial = (
-                     iorthotropic.CustomData[AdapterIdName].ToString() + "," + type + "," +
-                    new string(iorthotropic.DescriptionOrName().Replace(",","").Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
+                     iorthotropic.AdapterId<string>(typeof(MidasCivilId)) + "," + type + "," +
+                    new string(iorthotropic.DescriptionOrName().Replace(",", "").Take(materialCharacterLimit).ToArray()) + ",0,0,,C,NO," +
                     iorthotropic.DampingRatio + ",3,"
-                    +   iorthotropic.YoungsModulus.X.PressureFromSI(forceUnit, lengthUnit) + "," + 
-                        iorthotropic.YoungsModulus.Y.PressureFromSI(forceUnit, lengthUnit) + "," + 
+                    + iorthotropic.YoungsModulus.X.PressureFromSI(forceUnit, lengthUnit) + "," +
+                        iorthotropic.YoungsModulus.Y.PressureFromSI(forceUnit, lengthUnit) + "," +
                         iorthotropic.YoungsModulus.Z.PressureFromSI(forceUnit, lengthUnit) + ","
-                    +   iorthotropic.ThermalExpansionCoeff.X.InverseDeltaTemperatureFromSI(temperatureUnit) + "," + 
-                        iorthotropic.ThermalExpansionCoeff.Y.InverseDeltaTemperatureFromSI(temperatureUnit) + "," + 
+                    + iorthotropic.ThermalExpansionCoeff.X.InverseDeltaTemperatureFromSI(temperatureUnit) + "," +
+                        iorthotropic.ThermalExpansionCoeff.Y.InverseDeltaTemperatureFromSI(temperatureUnit) + "," +
                         iorthotropic.ThermalExpansionCoeff.Z.InverseDeltaTemperatureFromSI(temperatureUnit) + ","
-                    +   iorthotropic.ShearModulus.X.PressureFromSI(forceUnit, lengthUnit) + "," + 
-                        iorthotropic.ShearModulus.Y.PressureFromSI(forceUnit, lengthUnit) + "," + 
+                    + iorthotropic.ShearModulus.X.PressureFromSI(forceUnit, lengthUnit) + "," +
+                        iorthotropic.ShearModulus.Y.PressureFromSI(forceUnit, lengthUnit) + "," +
                         iorthotropic.ShearModulus.Z.PressureFromSI(forceUnit, lengthUnit) + ","
                     + iorthotropic.PoissonsRatio.X + "," + iorthotropic.PoissonsRatio.Y + "," + iorthotropic.PoissonsRatio.Z + ","
                     + iorthotropic.Density.DensityFromSI(forceUnit, lengthUnit) * 9.806 + "," + iorthotropic.Density.DensityFromSI(forceUnit, lengthUnit)

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -22,6 +22,8 @@
 
 using System;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Spatial.ShapeProfiles;
 using BH.Engine.Structure;
@@ -59,7 +61,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                    midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
                         new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                         ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
@@ -68,7 +70,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -92,7 +94,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                    midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
                         new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                         ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
@@ -101,7 +103,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -125,7 +127,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                    midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
                         new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                         ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
@@ -134,7 +136,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -158,7 +160,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                    midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
                         new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                         ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
@@ -167,7 +169,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }
@@ -191,7 +193,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",TAPERED," +
+                    midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
                         new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                         ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
@@ -200,7 +202,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             else
             {
-                midasSectionProperty.Add(sectionProperty.CustomData[AdapterIdName] + ",DBUSER," +
+                midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",DBUSER," +
                     new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                     ",CC, 0, 0, 0, 0, 0, 0, YES, NO," + CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
             }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
@@ -21,10 +21,10 @@
  */
 
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.Engine.Structure;
 using BH.oM.Structure.SurfaceProperties;
-
-using System;
 using System.Linq;
 
 namespace BH.Adapter.Adapters.MidasCivil
@@ -60,17 +60,17 @@ namespace BH.Adapter.Adapters.MidasCivil
                     case "8.9.5":
                     case "8.9.0":
                         midasSurfaceProperty =
-                            bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + ",VALUE,1,Yes," +
+                            bhomSurfaceProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE,1,Yes," +
                             bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,No,0,0";
                         break;
                     case "8.8.5":
                         midasSurfaceProperty =
-                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + "," + new string(bhomSurfaceProperty.DescriptionOrName().Replace(",","").Take(groupCharacterLimit).ToArray())
+                        bhomSurfaceProperty.AdapterId<string>(typeof(MidasCivilId)) + "," + new string(bhomSurfaceProperty.DescriptionOrName().Replace(",", "").Take(groupCharacterLimit).ToArray())
                         + ",VALUE,Yes," + bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,No,0,0";
                         break;
                     default:
                         midasSurfaceProperty =
-                        bhomSurfaceProperty.CustomData[AdapterIdName].ToString() + ",VALUE,Yes," +
+                        bhomSurfaceProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE,Yes," +
                         bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,No,0,0";
                         break;
                 }

--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -27,6 +27,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.IO;
 using BH.Engine.Base.Objects;
+using BH.oM.Adapters.MidasCivil;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using BH.oM.Structure.MaterialFragments;
@@ -50,7 +51,7 @@ namespace BH.Adapter.MidasCivil
         {
             if (active)
             {
-                AdapterIdName = "MidasCivil_id";   //Set the "AdapterId" to "SoftwareName_id". Generally stored as a constant string in the convert class in the SoftwareName_Engine
+                AdapterIdFragmentType = typeof(MidasCivilId);
 
                 Modules.Structure.ModuleLoader.LoadModules(this);
 
@@ -155,12 +156,12 @@ namespace BH.Adapter.MidasCivil
                         m_heatUnit = units[2].Trim();
                         m_temperatureUnit = units[3].Trim();
                     }
-                    catch(DirectoryNotFoundException)
+                    catch (DirectoryNotFoundException)
                     {
                         Engine.Reflection.Compute.RecordWarning(
                             "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
                     }
-                    catch(ArgumentOutOfRangeException)
+                    catch (ArgumentOutOfRangeException)
                     {
                         Engine.Reflection.Compute.RecordWarning(
                             "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -79,6 +79,10 @@
       <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="MidasCivil_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
@@ -129,7 +133,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Convert\AdapterIdName.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToBar.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToFEMesh.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToNode.cs" />

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -79,9 +79,10 @@
       <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="MidasCivil_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MidasCivil_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -79,11 +79,6 @@
       <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="MidasCivil_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
-	  <Private>False</Private>
-    </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
@@ -315,6 +310,10 @@
       <Project>{bc0a8eff-4277-49e9-bbdc-66ffa11e5258}</Project>
       <Name>MidasCivil_Engine</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\MidasCivil_oM\MidasCivil_oM.csproj">
+      <Project>{ec91e4d3-1fce-4547-8482-b78df69f56a8}</Project>
+      <Name>MidasCivil_oM</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/MidasCivil_Adapter/PrivateHelpers/CombineLoads.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/CombineLoads.cs
@@ -22,6 +22,8 @@
 
 using System.Linq;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
@@ -40,7 +42,7 @@ namespace BH.Adapter.MidasCivil
             var groupedByLoadCase = loads.GroupBy(x => x.Loadcase);
 
             Dictionary<string, Bar> barDictionary = bars.ToDictionary(
-                x => x.CustomData[Engine.Adapters.MidasCivil.Convert.AdapterIdName].ToString());
+                x => x.AdapterId<string>(typeof(MidasCivilId)));
 
             foreach (var loadcaseGroup in groupedByLoadCase)
             {
@@ -82,7 +84,7 @@ namespace BH.Adapter.MidasCivil
 
                         foreach (var element in load.Objects.Elements)
                         {
-                            loadBar.Add(element.CustomData[Engine.Adapters.MidasCivil.Convert.AdapterIdName].ToString());
+                            loadBar.Add(element.AdapterId<string>(typeof(MidasCivilId)));
                         }
 
                         loadBars.Add(loadBar);

--- a/MidasCivil_Adapter/PrivateHelpers/CreateGroups.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/CreateGroups.cs
@@ -23,6 +23,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 
 namespace BH.Adapter.MidasCivil
@@ -75,13 +77,13 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (!groupsToAdd.ContainsKey(tag))
                     {
-                        groupsToAdd.Add(tag, node.CustomData[AdapterIdName].ToString());
+                        groupsToAdd.Add(tag, node.AdapterId<string>(typeof(MidasCivilId)));
                     }
                     else
                     {
                         string assignedNodes;
                         groupsToAdd.TryGetValue(tag, out assignedNodes);
-                        string bhomID = node.CustomData[AdapterIdName].ToString();
+                        string bhomID = node.AdapterId<string>(typeof(MidasCivilId));
 
                         if (!assignedNodes.Contains(bhomID))
                         {
@@ -158,13 +160,13 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (!groupsToAdd.ContainsKey(tag))
                     {
-                        groupsToAdd.Add(tag, bar.CustomData[AdapterIdName].ToString());
+                        groupsToAdd.Add(tag, bar.AdapterId<string>(typeof(MidasCivilId)));
                     }
                     else
                     {
                         string assignedBars;
                         groupsToAdd.TryGetValue(tag, out assignedBars);
-                        string bhomID = bar.CustomData[AdapterIdName].ToString();
+                        string bhomID = bar.AdapterId<string>(typeof(MidasCivilId));
 
                         if (!assignedBars.Contains(bhomID))
                         {
@@ -239,13 +241,13 @@ namespace BH.Adapter.MidasCivil
                 {
                     if (!groupsToAdd.ContainsKey(tag))
                     {
-                        groupsToAdd.Add(tag, mesh.CustomData[AdapterIdName].ToString());
+                        groupsToAdd.Add(tag, mesh.AdapterId<string>(typeof(MidasCivilId)));
                     }
                     else
                     {
                         string assignedFEMesh;
                         groupsToAdd.TryGetValue(tag, out assignedFEMesh);
-                        string bhomID = mesh.CustomData[AdapterIdName].ToString();
+                        string bhomID = mesh.AdapterId<string>(typeof(MidasCivilId));
 
                         if (!assignedFEMesh.Contains(bhomID))
                         {

--- a/MidasCivil_Adapter/PrivateHelpers/GetSectionMaterialCombinations.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/GetSectionMaterialCombinations.cs
@@ -22,8 +22,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using BH.oM.Adapters.MidasCivil;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Adapter;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -56,33 +58,39 @@ namespace BH.Adapter.MidasCivil
                     case "Concrete":
                         ConcreteSection concreteSection = Engine.Structure.Create.ConcreteSectionFromProfile(genericSection.SectionProfile, (Concrete)material);
                         concreteSection.Name = genericSection.Name;
+                        concreteSection.SetAdapterId(typeof(MidasCivilId),sectionPropertyId);
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), concreteSection);
                         break;
                     case "Steel":
                         SteelSection steelSection = Engine.Structure.Create.SteelSectionFromProfile(genericSection.SectionProfile, (Steel)material);
                         steelSection.Name = genericSection.Name;
+                        steelSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), steelSection);
                         break;
                     case "Aluminium":
                         AluminiumSection aluminiumSection = Engine.Structure.Create.AluminiumSectionFromProfile(genericSection.SectionProfile, (Aluminium)material);
                         aluminiumSection.Name = genericSection.Name;
+                        aluminiumSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), aluminiumSection);
                         break;
                     case "Timber":
                         TimberSection timberSection = Engine.Structure.Create.TimberSectionFromProfile(genericSection.SectionProfile, (Timber)material);
                         timberSection.Name = genericSection.Name;
+                        timberSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
                         break;
                     case "GenericIsotropicMaterial":
                         GenericSection genericIsoptropicSection =
                             Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericIsotropicMaterial)material);
                         genericIsoptropicSection.Name = genericSection.Name;
+                        genericIsoptropicSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericIsoptropicSection);
                         break;
                     case "GenericOrthotropicMaterial":
                         GenericSection genericOrthotropicSection =
                             Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericOrthotropicMaterial)material);
                         genericOrthotropicSection.Name = genericSection.Name;
+                        genericOrthotropicSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
                         materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericOrthotropicSection);
                         break;
                     default:

--- a/MidasCivil_Adapter/Type/NextFreeId.cs
+++ b/MidasCivil_Adapter/Type/NextFreeId.cs
@@ -22,6 +22,8 @@
 
 using System;
 using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.SectionProperties;
@@ -60,7 +62,7 @@ namespace BH.Adapter.MidasCivil
                     {
                         List<Node> nodes = ReadNodes();
                         List<int> nodeID = new List<int>();
-                        nodes.ForEach(x => nodeID.Add(System.Convert.ToInt32(x.CustomData[AdapterIdName].ToString())));
+                        nodes.ForEach(x => nodeID.Add(System.Convert.ToInt32(x.AdapterId<string>(typeof(MidasCivilId)))));
                         nodeID.Sort();
                         nodeID.Reverse();
 
@@ -116,7 +118,7 @@ namespace BH.Adapter.MidasCivil
                     if (ExistsSection(section))
                     {
 
-                        index = GetMaxId(section) +1;
+                        index = GetMaxId(section) + 1;
                     }
                     else
                     {
@@ -124,7 +126,7 @@ namespace BH.Adapter.MidasCivil
                     }
                 }
 
-                if(typeof(ISectionProperty).IsAssignableFrom(type))
+                if (typeof(ISectionProperty).IsAssignableFrom(type))
                 {
                     string section = "SECTION";
 
@@ -154,8 +156,8 @@ namespace BH.Adapter.MidasCivil
 
             }
 
-                m_indexDict[type] = index;
-                return index;
+            m_indexDict[type] = index;
+            return index;
         }
 
 

--- a/MidasCivil_Engine/Compute/FEMeshToPanel.cs
+++ b/MidasCivil_Engine/Compute/FEMeshToPanel.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
 using System.Collections.Generic;
@@ -49,8 +51,8 @@ namespace BH.Engine.Adapters.MidasCivil
 
             List<Panel> panels = BH.Engine.Structure.Create.Panel(polylines.Cast<ICurve>().ToList());
 
-            if (mesh.CustomData.ContainsValue(Convert.AdapterIdName))
-                panels[0].CustomData[Convert.AdapterIdName] = mesh.CustomData[Convert.AdapterIdName];
+            if (mesh.HasAdapterIdFragment(typeof(MidasCivilId)))
+                panels[0].SetAdapterId(typeof(MidasCivilId), mesh.AdapterId<int>(typeof(MidasCivilId)));
 
             return panels[0];
         }

--- a/MidasCivil_Engine/MidasCivil_Engine.csproj
+++ b/MidasCivil_Engine/MidasCivil_Engine.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Adapter_Engine">
+      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Analytical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
       <Private>False</Private>
@@ -55,6 +58,10 @@
     <Reference Include="Library_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="MidasCivil_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
     </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>

--- a/MidasCivil_Engine/MidasCivil_Engine.csproj
+++ b/MidasCivil_Engine/MidasCivil_Engine.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="Adapter_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Analytical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
@@ -58,11 +58,6 @@
     </Reference>
     <Reference Include="Library_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Library_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MidasCivil_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Physical_oM">
@@ -110,6 +105,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MidasCivil_oM\MidasCivil_oM.csproj">
+      <Project>{ec91e4d3-1fce-4547-8482-b78df69f56a8}</Project>
+      <Name>MidasCivil_oM</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/MidasCivil_Engine/MidasCivil_Engine.csproj
+++ b/MidasCivil_Engine/MidasCivil_Engine.csproj
@@ -31,7 +31,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Adapter_Engine">
-      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="Analytical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
@@ -59,9 +60,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Library_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MidasCivil_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MidasCivil_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\MidasCivil_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Physical_oM">
       <SpecificVersion>False</SpecificVersion>

--- a/MidasCivil_oM/Fragments/MidasCivilId.cs
+++ b/MidasCivil_oM/Fragments/MidasCivilId.cs
@@ -20,12 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System.ComponentModel;
 using System.Collections.Generic;
 
 namespace BH.oM.Adapters.MidasCivil
 {
-    public class MidasCivilId
+    public class MidasCivilId : IAdapterId
     {
         /***************************************************/
         /**** Public Properties                         ****/

--- a/MidasCivil_oM/Fragments/MidasCivilId.cs
+++ b/MidasCivil_oM/Fragments/MidasCivilId.cs
@@ -20,23 +20,20 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
+using System.ComponentModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace BH.Adapter.Adapters.MidasCivil
+namespace BH.oM.Adapters.MidasCivil
 {
-    public static partial class Convert
+    public class MidasCivilId
     {
         /***************************************************/
-        /**** Public Constants                          ****/
+        /**** Public Properties                         ****/
         /***************************************************/
 
-        public const string AdapterIdName = "MidasCivil_id";
+        [Description("Id or multi-ids of the element as assigned in MidasCivil.")]
+        public virtual object Id { get; set; }
 
         /***************************************************/
-
     }
 }

--- a/MidasCivil_oM/MidasCivil_oM.csproj
+++ b/MidasCivil_oM/MidasCivil_oM.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -44,6 +44,7 @@
     <Compile Include="Enum\HeatUnit.cs" />
     <Compile Include="Enum\LengthUnit.cs" />
     <Compile Include="Enum\TemperatureUnit.cs" />
+    <Compile Include="Fragments\MidasCivilId.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/MidasCivil_oM/MidasCivil_oM.csproj
+++ b/MidasCivil_oM/MidasCivil_oM.csproj
@@ -30,6 +30,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+	  <Private>False</Private>
+	  <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1033
https://github.com/BHoM/BHoM_Engine/pull/2106

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Closes #261 

Aligning with changes in https://github.com/BHoM/BHoM/issues/1012

 <!-- Add short description of what has been fixed -->

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EiJywS8APoBAg7RiC4c0rRsBlYH8jZvgGJS4f6PlobSbaA?e=w0KZrC

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removes the use of `CustomData` and `MidasCivilId` will now be stored as `Fragments`