### PR TITLE
Add various AdapterActions

### DIFF
--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -220,8 +220,8 @@ namespace BH.Adapter.MidasCivil
 
         public bool RunCommand(ClearResults command)
         {
-            Engine.Reflection.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter.");
-            return false;
+            Directory.Delete(m_directory + "\\Results");
+            return true;
         }
 
         /***************************************************/

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -232,7 +232,12 @@ namespace BH.Adapter.MidasCivil
 
         public bool RunCommand(ClearResults command)
         {
-            Directory.Delete(m_directory + "\\Results");
+            DirectoryInfo directory = new DirectoryInfo(m_directory + "\\Results");
+            foreach (FileInfo file in directory.EnumerateFiles())
+            {
+                file.Delete();
+            }
+
             return true;
         }
 

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -29,6 +29,7 @@ using BH.oM.Adapter;
 using BH.oM.Reflection;
 using BH.oM.Adapter.Commands;
 using BH.oM.Structure.Loads;
+using System.Runtime.InteropServices;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -72,12 +73,15 @@ namespace BH.Adapter.MidasCivil
             string unitFile = m_directory + unitExtension;
             string versionFile = m_directory + versionExtension;
 
-
             if (!File.Exists(unitFile))
                 File.Copy(unitFile, newDirectory + unitExtension);
+            else
+                File.AppendAllLines(m_directory + unitExtension, new List<string>() {"*UNIT","N,M,BTU,C"});
 
             if (!File.Exists(versionFile))
                 File.Copy(versionFile, newDirectory + versionExtension);
+            else
+                File.AppendAllLines(m_directory + versionExtension, new List<string>() { "*VERSION", m_midasCivilVersion });
 
             m_directory = newDirectory;
             Directory.CreateDirectory(newDirectory + "\\Results");
@@ -112,8 +116,6 @@ namespace BH.Adapter.MidasCivil
             string[] mctFiles = Directory.GetFiles(m_directory, "*.mcb");
             foreach (string mctFile in mctFiles)
                 File.Copy(mctFile, newDirectory);
-
-
             CopyAll(new DirectoryInfo(m_directory + "\\TextFiles"), new DirectoryInfo(newDirectory + "\\TextFiles"));
             CopyAll(new DirectoryInfo(m_directory + "\\Results"), new DirectoryInfo(newDirectory + "\\Results"));
 

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -1,0 +1,258 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapter;
+using BH.oM.Reflection;
+using BH.oM.Adapter.Commands;
+using BH.oM.Structure.Loads;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+
+    {
+        /***************************************************/
+        /**** IAdapter Interface                        ****/
+        /***************************************************/
+
+        public override Output<List<object>, bool> Execute(IExecuteCommand command, ActionConfig actionConfig = null)
+        {
+            var output = new Output<List<object>, bool>() { Item1 = null, Item2 = false };
+
+            output.Item2 = RunCommand(command as dynamic);
+
+            return output;
+        }
+
+        /***************************************************/
+        /**** Commands                                  ****/
+        /***************************************************/
+
+        public bool RunCommand(NewModel command)
+        {
+            string newDirectory = GetDirectoryRoot(m_directory) + "\\Untitled";
+
+            bool directoryExists = Directory.Exists(newDirectory);
+
+            int i = 1;
+
+            while (directoryExists)
+            {
+                newDirectory = newDirectory + 1;
+                directoryExists = Directory.Exists(newDirectory);
+                i++;
+            }
+
+            string unitExtension = "\\TextFiles\\" + "UNIT" + ".txt";
+            string versionExtension = "\\TextFiles\\" + "VERSION" + ".txt";
+            string unitFile = m_directory + unitExtension;
+            string versionFile = m_directory + versionExtension;
+
+
+            if (!File.Exists(unitFile))
+                File.Copy(unitFile, newDirectory + unitExtension);
+
+            if (!File.Exists(versionFile))
+                File.Copy(versionFile, newDirectory + versionExtension);
+
+            m_directory = newDirectory;
+
+            return true;
+        }
+
+        /***************************************************/
+
+        public bool RunCommand(Save command)
+        {
+            Engine.Reflection.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter.");
+            return false;
+        }
+
+        /***************************************************/
+
+        public bool RunCommand(SaveAs command)
+        {
+            string newDirectory = GetDirectoryRoot(m_directory) + "\\" + command.FileName;
+
+            if (Directory.Exists(newDirectory))
+            {
+                Engine.Reflection.Compute.RecordError("File with the same name already exists, please choose another.");
+                return false;
+            }
+
+            Directory.CreateDirectory(newDirectory);
+            CopyAll(new DirectoryInfo(m_directory + "\\TEXTFILES"), new DirectoryInfo(newDirectory + "\\TEXTFILES"));
+
+            m_directory = newDirectory;
+
+            return true;
+        }
+
+        /***************************************************/
+
+        public bool RunCommand(Open command)
+        {
+            string filePath = command.FileName;
+
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentException("No file path given");
+            }
+            else if (IsApplicationRunning())
+            {
+                throw new Exception("MidasCivil process already running");
+            }
+            else
+            {
+                try
+                {
+                    System.Diagnostics.Process.Start(filePath);
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                    throw new Exception("File does not exist, please reference an .mcb file");
+                }
+                m_directory = Path.GetDirectoryName(filePath);
+                string fileName = Path.GetFileNameWithoutExtension(filePath);
+                string txtFile = m_directory + "\\" + fileName + ".txt";
+                string mctFile = m_directory + "\\" + fileName + ".mct";
+
+                if (File.Exists(txtFile))
+                {
+                    m_midasText = File.ReadAllLines(txtFile).ToList();
+                    SetSectionText();
+                }
+                else if (File.Exists(mctFile))
+                {
+                    m_midasText = File.ReadAllLines(mctFile).ToList();
+                    SetSectionText();
+                }
+                string versionFile = m_directory + "\\TextFiles\\" + "VERSION" + ".txt";
+                m_midasCivilVersion = "8.8.1";
+
+                if (!(m_midasCivilVersion == ""))
+                {
+                    m_midasCivilVersion = m_midasCivilVersion.Trim();
+                    if (File.Exists(versionFile))
+                    {
+                        Engine.Reflection.Compute.RecordWarning("*VERSION file found, user input used to overide: version =  " + m_midasCivilVersion);
+                    }
+                }
+                else if (File.Exists(versionFile))
+                {
+                    List<string> versionText = GetSectionText("VERSION");
+                    m_midasCivilVersion = versionText[0].Trim();
+                }
+                else
+                {
+                    Engine.Reflection.Compute.RecordWarning("*VERSION file not found in directory and no version specified, MidasCivil version assumed default value =  " + m_midasCivilVersion);
+                }
+
+                try
+                {
+                    List<string> units = GetSectionText("UNIT")[0].Split(',').ToList();
+                    m_forceUnit = units[0].Trim();
+                    m_lengthUnit = units[1].Trim();
+                    m_heatUnit = units[2].Trim();
+                    m_temperatureUnit = units[3].Trim();
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    Engine.Reflection.Compute.RecordWarning(
+                        "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    Engine.Reflection.Compute.RecordWarning(
+                        "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
+                }
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        public bool RunCommand(Analyse command)
+        {
+            Engine.Reflection.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter.");
+            return false;
+        }
+
+        /***************************************************/
+
+        public bool RunCommand(AnalyseLoadCases command)
+        {
+            Engine.Reflection.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter.");
+            return false;
+        }
+
+        /***************************************************/
+
+        public bool RunCommand(ClearResults command)
+        {
+            Engine.Reflection.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter.");
+            return false;
+        }
+
+        /***************************************************/
+
+        public bool RunCommand(IExecuteCommand command)
+        {
+            Engine.Reflection.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter.");
+            return false;
+        }
+
+        /***************************************************/
+        /**** Private helper methods                    ****/
+        /***************************************************/
+        private string GetDirectoryRoot(string directory)
+        {
+            List<string> directoryRoot = m_directory.Split('\\').ToList();
+            directoryRoot.RemoveAt(directoryRoot.Count - 1);
+
+            return String.Join("\\", directoryRoot.ToArray());
+        }
+
+        private static void CopyAll(DirectoryInfo sourceDirectory, DirectoryInfo targetDirectory)
+        {
+            Directory.CreateDirectory(targetDirectory.FullName);
+
+            foreach (FileInfo file in sourceDirectory.GetFiles())
+                file.CopyTo(Path.Combine(targetDirectory.FullName, file.Name));
+
+            foreach (DirectoryInfo sourceSubDirectory in sourceDirectory.GetDirectories())
+            {
+                DirectoryInfo targetSubDirectory = targetDirectory.CreateSubdirectory(sourceSubDirectory.Name);
+                CopyAll(sourceSubDirectory, targetSubDirectory);
+            }
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -106,10 +106,18 @@ namespace BH.Adapter.MidasCivil
             }
 
             Directory.CreateDirectory(newDirectory);
-            CopyAll(new DirectoryInfo(m_directory + "\\TEXTFILES"), new DirectoryInfo(newDirectory + "\\TEXTFILES"));
+            string[] mcbFiles = Directory.GetFiles(m_directory, "*.mcb");
+            foreach (string mcbFile in mcbFiles)
+                File.Copy(mcbFile, newDirectory);
+            string[] mctFiles = Directory.GetFiles(m_directory, "*.mcb");
+            foreach (string mctFile in mctFiles)
+                File.Copy(mctFile, newDirectory);
+
+
+            CopyAll(new DirectoryInfo(m_directory + "\\TextFiles"), new DirectoryInfo(newDirectory + "\\TextFiles"));
+            CopyAll(new DirectoryInfo(m_directory + "\\Results"), new DirectoryInfo(newDirectory + "\\Results"));
 
             m_directory = newDirectory;
-            Directory.CreateDirectory(newDirectory + "\\Results");
 
             return true;
         }

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -73,15 +73,17 @@ namespace BH.Adapter.MidasCivil
             string unitFile = m_directory + unitExtension;
             string versionFile = m_directory + versionExtension;
 
+            Directory.CreateDirectory(newDirectory + "\\TextFiles");
+
             if (!File.Exists(unitFile))
                 File.Copy(unitFile, newDirectory + unitExtension);
             else
-                File.AppendAllLines(m_directory + unitExtension, new List<string>() {"*UNIT","N,M,BTU,C"});
+                File.AppendAllLines(newDirectory + unitExtension, new List<string>() {"*UNIT","N,M,BTU,C"});
 
             if (!File.Exists(versionFile))
                 File.Copy(versionFile, newDirectory + versionExtension);
             else
-                File.AppendAllLines(m_directory + versionExtension, new List<string>() { "*VERSION", m_midasCivilVersion });
+                File.AppendAllLines(newDirectory + versionExtension, new List<string>() { "*VERSION", m_midasCivilVersion });
 
             m_directory = newDirectory;
             Directory.CreateDirectory(newDirectory + "\\Results");

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -80,6 +80,7 @@ namespace BH.Adapter.MidasCivil
                 File.Copy(versionFile, newDirectory + versionExtension);
 
             m_directory = newDirectory;
+            Directory.CreateDirectory(newDirectory + "\\Results");
 
             return true;
         }
@@ -108,6 +109,7 @@ namespace BH.Adapter.MidasCivil
             CopyAll(new DirectoryInfo(m_directory + "\\TEXTFILES"), new DirectoryInfo(newDirectory + "\\TEXTFILES"));
 
             m_directory = newDirectory;
+            Directory.CreateDirectory(newDirectory + "\\Results");
 
             return true;
         }
@@ -190,6 +192,9 @@ namespace BH.Adapter.MidasCivil
                     Engine.Reflection.Compute.RecordWarning(
                         "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
                 }
+
+                Directory.CreateDirectory(m_directory + "\\Results");
+
             }
 
             return true;

--- a/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
@@ -74,7 +74,7 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractBarStress(List<int> ids, List<string> loadcaseIds)
         {
 
-            string filePath = m_directory + "\\Beam Stress.xls";
+            string filePath = m_directory + "\\Results\\Beam Stress.xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> barStressText = File.ReadAllLines(csvPath).ToList();
             List<BarStress> barStresses = new List<BarStress>();
@@ -115,7 +115,7 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractBarForce(List<int> ids, List<string> loadcaseIds)
         {
 
-            string filePath = m_directory + "\\Beam Force.xls";
+            string filePath = m_directory + "\\Results\\Beam Force.xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> barForceText = File.ReadAllLines(csvPath).ToList();
             List<BarForce> barForces = new List<BarForce>();

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -81,7 +81,7 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractMeshForce(List<int> ids, List<string> loadcaseIds)
         {
             /***************************************************/
-            string filePath = m_directory + "\\Plate Force(UL_Local).xls";
+            string filePath = m_directory + "\\Results\\Plate Force(UL_Local).xls";
             string csvPath = ExcelToCsv(filePath);
             List<string> meshForceText = File.ReadAllLines(csvPath).ToList();
             List<MeshForce> meshForces = new List<MeshForce>();
@@ -108,7 +108,7 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractMeshStress(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
         {
             /***************************************************/
-            string filePath = m_directory + "\\Plate Stress(L).xls";
+            string filePath = m_directory + "\\Results\\Plate Stress(L).xls";
             string csvPath = ExcelToCsv(filePath);
             List<string> meshStressText = File.ReadAllLines(csvPath).ToList();
             List<MeshStress> meshStresses = new List<MeshStress>();
@@ -145,7 +145,7 @@ namespace BH.Adapter.MidasCivil
         private IEnumerable<IResult> ExtractMeshVonMises(List<int> ids, List<string> loadcaseIds, MeshResultLayer meshResultLayer)
         {
             /***************************************************/
-            string filePath = m_directory + "\\Plate Stress(L).xls";
+            string filePath = m_directory + "\\Results\\Plate Stress(L).xls";
             string csvPath = ExcelToCsv(filePath);
             List<string> meshVonMisesText = File.ReadAllLines(csvPath).ToList();
             List<MeshVonMises> meshVonMiseses = new List<MeshVonMises>();

--- a/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.MidasCivil
 
         private IEnumerable<IResult> ExtractNodeReaction(List<int> ids, List<string> loadcaseIds)
         {
-            string filePath = m_directory + "\\Reaction(Global).xls";
+            string filePath = m_directory + "\\Results\\Reaction(Global).xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> nodeReactionText = File.ReadAllLines(csvPath).ToList();
             List<NodeReaction> nodeReactions = new List<NodeReaction>();
@@ -96,7 +96,7 @@ namespace BH.Adapter.MidasCivil
 
         private IEnumerable<IResult> ExtractNodeDisplacement(List<int> ids, List<string> loadcaseIds)
         {
-            string filePath = m_directory + "\\Displacements(Global).xls";
+            string filePath = m_directory + "\\Results\\Displacements(Global).xls";
             string csvPath = ExcelToCsv(filePath);
             List<String> nodeDisplacementText = File.ReadAllLines(csvPath).ToList();
 

--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -36,6 +36,7 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Loads;
 using BH.Engine.Adapters.MidasCivil.Comparer;
 using BH.Engine.Structure;
+using BH.oM.Adapter.Commands;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -94,79 +95,9 @@ namespace BH.Adapter.MidasCivil
                     {typeof(ILoad), new List<Type> {typeof(Loadcase) } }
                 };
 
-                if (string.IsNullOrWhiteSpace(filePath))
-                {
-                    throw new ArgumentException("No file path given");
-                }
-                else if (IsApplicationRunning())
-                {
-                    throw new Exception("MidasCivil process already running");
-                }
-                else
-                {
-                    try
-                    {
-                        System.Diagnostics.Process.Start(filePath);
-                    }
-                    catch (System.ComponentModel.Win32Exception)
-                    {
-                        throw new Exception("File does not exist, please reference an .mcb file");
-                    }
-                    m_directory = Path.GetDirectoryName(filePath);
-                    string fileName = Path.GetFileNameWithoutExtension(filePath);
-                    string txtFile = m_directory + "\\" + fileName + ".txt";
-                    string mctFile = m_directory + "\\" + fileName + ".mct";
+                m_midasCivilVersion = version;
 
-                    if (File.Exists(txtFile))
-                    {
-                        m_midasText = File.ReadAllLines(txtFile).ToList();
-                        SetSectionText();
-                    }
-                    else if (File.Exists(mctFile))
-                    {
-                        m_midasText = File.ReadAllLines(mctFile).ToList();
-                        SetSectionText();
-                    }
-                    string versionFile = m_directory + "\\TextFiles\\" + "VERSION" + ".txt";
-                    m_midasCivilVersion = "8.8.1";
-
-                    if (!(version == ""))
-                    {
-                        m_midasCivilVersion = version.Trim();
-                        if (File.Exists(versionFile))
-                        {
-                            Engine.Reflection.Compute.RecordWarning("*VERSION file found, user input used to overide: version =  " + m_midasCivilVersion);
-                        }
-                    }
-                    else if (File.Exists(versionFile))
-                    {
-                        List<string> versionText = GetSectionText("VERSION");
-                        m_midasCivilVersion = versionText[0].Trim();
-                    }
-                    else
-                    {
-                        Engine.Reflection.Compute.RecordWarning("*VERSION file not found in directory and no version specified, MidasCivil version assumed default value =  " + m_midasCivilVersion);
-                    }
-
-                    try
-                    {
-                        List<string> units = GetSectionText("UNIT")[0].Split(',').ToList();
-                        m_forceUnit = units[0].Trim();
-                        m_lengthUnit = units[1].Trim();
-                        m_heatUnit = units[2].Trim();
-                        m_temperatureUnit = units[3].Trim();
-                    }
-                    catch (DirectoryNotFoundException)
-                    {
-                        Engine.Reflection.Compute.RecordWarning(
-                            "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
-                    }
-                    catch (ArgumentOutOfRangeException)
-                    {
-                        Engine.Reflection.Compute.RecordWarning(
-                            "No UNITS.txt file found, MidasCivil model units assumed to be Newtons, metres, calories and celcius. Therefore, no unit conversion will occur when pushing and pulling to/from MidasCivil.");
-                    }
-                }
+                Execute(new Open() { FileName = filePath });
             }
         }
 

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -129,6 +129,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdapterActions\Execute.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToBar.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToFEMesh.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToNode.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #264 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/ErxmGOmmN8NBgJlqNkc3AbYBeORcs5tkjRCKIUEbgCxQJQ?e=sAdf2k

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `AdapterActions` such as `NewModel`, `OpenFile`, `SaveAs` and `ClearResults`
- Migrated the expected directory for results to `m_directory\Results` similar to where TextFiles are stored (`m_directory\TextFiles`)
- This allows for the easy removal of the `Results` directory when invoking `ClearResults`
- When `NewModel` is invoked, the `Units` and `MidasCivilVersion` files (if available) will be copied, otherwise they will default SI Units and the default `MidasCivilVersion` which is currently `8.8.1`
- When `SaveAs` is invoked, all the files in the `\TextFiles` and `\Results\` folders will be copied over along with the `.mcb` and `.mct` file