### PR TITLE
Fix bug where *VERSION was not correctly set

### DIFF
--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -165,9 +165,8 @@ namespace BH.Adapter.MidasCivil
                     m_midasText = File.ReadAllLines(mctFile).ToList();
                     SetSectionText();
                 }
-                string versionFile = m_directory + "\\TextFiles\\" + "VERSION" + ".txt";
-                m_midasCivilVersion = "8.8.1";
 
+                string versionFile = m_directory + "\\TextFiles\\" + "VERSION" + ".txt";
                 if (!(m_midasCivilVersion == ""))
                 {
                     m_midasCivilVersion = m_midasCivilVersion.Trim();
@@ -183,6 +182,7 @@ namespace BH.Adapter.MidasCivil
                 }
                 else
                 {
+                    m_midasCivilVersion = "8.8.1";
                     Engine.Reflection.Compute.RecordWarning("*VERSION file not found in directory and no version specified, MidasCivil version assumed default value =  " + m_midasCivilVersion);
                 }
 

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SurfaceProperty.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SurfaceProperty.cs
@@ -44,8 +44,6 @@ namespace BH.Adapter.MidasCivil
 
                 switch (m_midasCivilVersion)
                 {
-                    case "8.9.5":
-                    case "8.9.0":
                     case "8.8.5":
                         type = surfaceProperty.Split(',')[2].Trim();
                         break;

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SurfaceProperty.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SurfaceProperty.cs
@@ -44,6 +44,8 @@ namespace BH.Adapter.MidasCivil
 
                 switch (m_midasCivilVersion)
                 {
+                    case "8.9.5":
+                    case "8.9.0":
                     case "8.8.5":
                         type = surfaceProperty.Split(',')[2].Trim();
                         break;

--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -112,7 +112,7 @@ namespace BH.Adapter.MidasCivil
 
         private List<string> m_midasText;
         private string m_directory;
-        private string m_midasCivilVersion;
+        public string m_midasCivilVersion { get; protected set; }
         private string m_forceUnit;
         private string m_lengthUnit;
         private string m_heatUnit;

--- a/MidasCivil_Engine/MidasCivil_Engine.csproj
+++ b/MidasCivil_Engine/MidasCivil_Engine.csproj
@@ -105,7 +105,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Modify\" />
-    <Folder Include="Query\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #251 
Closes #286 

<!-- Add short description of what has been fixed -->
- Changed when a default `m_midasCivilVersion` was set 
- Made `m_midasCivilVersion` `public` so it is viewable from exploding the `Adapter`

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/Archive/MidasCivil_Toolkit/MidasCivil_Toolkit-%23286?csf=1&web=1&e=2xc3Iy

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug the `m_midasCivilVersion` was defaulting to 8.8.1 despite using an override within the adapter