### PR TITLE
Added method to convert 3/4 noded Panels to FEMesh objects

### DIFF
--- a/MidasCivil_Engine/Compute/PanelToFEMesh.cs
+++ b/MidasCivil_Engine/Compute/PanelToFEMesh.cs
@@ -35,20 +35,30 @@ namespace BH.Engine.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static FEMesh PanelToFEMesh(Panel panel, Face face)
+        public static FEMesh PanelToFEMesh(Panel panel)
         {
             List<Point> points = new List<Point>();
             List<Edge> edges = panel.ExternalEdges;
             List<ICurve> curves = new List<ICurve>();
             List<Face> faces = new List<Face>();
-            faces.Add(face);
+            Face face = new Face();
 
             foreach (Edge edge in edges)
             {
                 ICurve curve = BH.Engine.Analytical.Query.Geometry(edge);
+                int Count = BH.Engine.Geometry.Convert.IToPolyline(curve).ControlPoints.Count();
+                if (Count == 4)
+                {
+                    face = Geometry.Create.Face(3, 2, 1, 0);   
+                }
+                if (Count == 3)
+                {
+                    face = Geometry.Create.Face(2, 1, 0, -1);
+                }
+                faces.Add(face);
                 points.AddRange(BH.Engine.Geometry.Convert.IToPolyline(curve).ControlPoints);
             }
-        
+
             Mesh mesh = BH.Engine.Geometry.Create.Mesh(points.Distinct(), faces);
             FEMesh fEMesh = BH.Engine.Structure.Create.FEMesh(mesh, panel.Property,null,panel.Name);
 

--- a/MidasCivil_Engine/Compute/PanelToFEMesh.cs
+++ b/MidasCivil_Engine/Compute/PanelToFEMesh.cs
@@ -35,12 +35,11 @@ namespace BH.Engine.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static FEMesh PanelToFEMesh(Panel panel)
+        public static FEMesh PanelToFEMesh(Panel panel, Face face)
         {
             List<Point> points = new List<Point>();
             List<Edge> edges = panel.ExternalEdges;
             List<ICurve> curves = new List<ICurve>();
-            Face face = BH.Engine.Geometry.Create.Face(0, 1, 2);
             List<Face> faces = new List<Face>();
             faces.Add(face);
 
@@ -49,8 +48,9 @@ namespace BH.Engine.Adapters.MidasCivil
                 ICurve curve = BH.Engine.Analytical.Query.Geometry(edge);
                 points.AddRange(BH.Engine.Geometry.Convert.IToPolyline(curve).ControlPoints);
             }
-            Mesh mesh = BH.Engine.Geometry.Create.Mesh(points, faces);
-            FEMesh fEMesh = BH.Engine.Structure.Create.FEMesh(mesh, panel.Property);
+        
+            Mesh mesh = BH.Engine.Geometry.Create.Mesh(points.Distinct(), faces);
+            FEMesh fEMesh = BH.Engine.Structure.Create.FEMesh(mesh, panel.Property,null,panel.Name);
 
             return fEMesh;
         }

--- a/MidasCivil_Engine/Compute/PanelToFEMesh.cs
+++ b/MidasCivil_Engine/Compute/PanelToFEMesh.cs
@@ -24,9 +24,12 @@ using BH.oM.Adapters.MidasCivil;
 using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.Linq;
+using System.ComponentModel;
 using BH.Engine.Analytical;
+
 namespace BH.Engine.Adapters.MidasCivil
 {
     public static partial class Compute
@@ -34,6 +37,10 @@ namespace BH.Engine.Adapters.MidasCivil
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
+
+        [Description("Converting panel with 3 or 4 edges to FEmesh ")]
+        [Input("panel", "BH.oM.Structure.Elements.Panel with 3 or 4 edges")]
+        [Output("FEMesh", "BH.oM.Structure.Elements.FEMesh with 3 or 4 nodes")]
 
         public static FEMesh PanelToFEMesh(Panel panel)
         {
@@ -51,14 +58,17 @@ namespace BH.Engine.Adapters.MidasCivil
                 {
                     face = Geometry.Create.Face(3, 2, 1, 0);
                 }
-                if (Count == 3)
+                else if (Count == 3)
                 {
                     face = Geometry.Create.Face(2, 1, 0, -1);
                 }
+                if (face == null)
+                {
+                    return null;
+                }  
                 faces.Add(face);
                 points.AddRange(BH.Engine.Geometry.Convert.IToPolyline(curve).ControlPoints);
             }
-
             Mesh mesh = BH.Engine.Geometry.Create.Mesh(points.Distinct(), faces);
             FEMesh fEMesh = BH.Engine.Structure.Create.FEMesh(mesh, panel.Property, null, panel.Name);
 

--- a/MidasCivil_Engine/Compute/PanelToFEMesh.cs
+++ b/MidasCivil_Engine/Compute/PanelToFEMesh.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Adapters.MidasCivil
                 int Count = BH.Engine.Geometry.Convert.IToPolyline(curve).ControlPoints.Count();
                 if (Count == 4)
                 {
-                    face = Geometry.Create.Face(3, 2, 1, 0);   
+                    face = Geometry.Create.Face(3, 2, 1, 0);
                 }
                 if (Count == 3)
                 {
@@ -60,7 +60,7 @@ namespace BH.Engine.Adapters.MidasCivil
             }
 
             Mesh mesh = BH.Engine.Geometry.Create.Mesh(points.Distinct(), faces);
-            FEMesh fEMesh = BH.Engine.Structure.Create.FEMesh(mesh, panel.Property,null,panel.Name);
+            FEMesh fEMesh = BH.Engine.Structure.Create.FEMesh(mesh, panel.Property, null, panel.Name);
 
             return fEMesh;
         }

--- a/MidasCivil_Engine/Compute/PanelToFEMesh.cs
+++ b/MidasCivil_Engine/Compute/PanelToFEMesh.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
+using BH.oM.Structure.Elements;
+using BH.oM.Geometry;
+using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Analytical;
+namespace BH.Engine.Adapters.MidasCivil
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static FEMesh PanelToFEMesh(Panel panel)
+        {
+            List<Point> points = new List<Point>();
+            List<Edge> edges = panel.ExternalEdges;
+            List<ICurve> curves = new List<ICurve>();
+            Face face = BH.Engine.Geometry.Create.Face(0, 1, 2);
+            List<Face> faces = new List<Face>();
+            faces.Add(face);
+
+            foreach (Edge edge in edges)
+            {
+                ICurve curve = BH.Engine.Analytical.Query.Geometry(edge);
+                points.AddRange(BH.Engine.Geometry.Convert.IToPolyline(curve).ControlPoints);
+            }
+            Mesh mesh = BH.Engine.Geometry.Create.Mesh(points, faces);
+            FEMesh fEMesh = BH.Engine.Structure.Create.FEMesh(mesh, panel.Property);
+
+            return fEMesh;
+        }
+
+        /***************************************************/
+
+    }
+}
+

--- a/MidasCivil_Engine/MidasCivil_Engine.csproj
+++ b/MidasCivil_Engine/MidasCivil_Engine.csproj
@@ -35,7 +35,8 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Analytical_Engine">
-      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Analytical_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Analytical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>

--- a/MidasCivil_Engine/MidasCivil_Engine.csproj
+++ b/MidasCivil_Engine/MidasCivil_Engine.csproj
@@ -34,6 +34,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Analytical_Engine">
+      <HintPath>..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Analytical_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Analytical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
       <Private>False</Private>
@@ -97,6 +100,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compute\FEMeshToPanel.cs" />
+    <Compile Include="Compute\PanelToFEMesh.cs" />
     <Compile Include="Objects\AdapterIdName.cs" />
     <Compile Include="Objects\ArrayComparer.cs" />
     <Compile Include="Objects\MeshCentreComparer.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #290 

<!-- Add short description of what has been fixed -->
A new component `PaneltoFEMesh` is added. While using the test script, please test it by looking at the exploded view of the FEMesh and compare it with the exploded view of the panel. I have included a simple push to Midas in the test script as well.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?cid=506a082e%2Daf0c%2D43ad%2D8fb5%2D4505bb1e26bb&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FArchive%2FMidasCivil%5FToolkit%2FMidasCivil%5FToolkit%2D%23290

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added new component that allows conversion from 3/4 noded `Panels` to `FEMeshs`

