### PR TITLE
Fix bug where loads are not applied to FEMesh objects that have more than one FEMeshFace

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformTemperatureLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformTemperatureLoads.cs
@@ -46,9 +46,13 @@ namespace BH.Adapter.MidasCivil
 
                 List<string> assignedFEMeshes = new List<string>();
 
-                foreach (IAreaElement mesh in assignedElements)
+                foreach (FEMesh mesh in assignedElements)
                 {
-                    assignedFEMeshes.Add(mesh.AdapterId<string>(typeof(MidasCivilId)));
+                    List<FEMeshFace> faces = mesh.Faces;
+                    foreach (FEMeshFace face in faces)
+                    {
+                        assignedFEMeshes.Add(face.AdapterId<string>(typeof(MidasCivilId)));
+                    }
                 }
 
                 foreach (string assignedFEMesh in assignedFEMeshes)

--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
@@ -46,9 +46,13 @@ namespace BH.Adapter.MidasCivil
 
                 List<string> assignedFEMeshes = new List<string>();
 
-                foreach (IAreaElement mesh in assignedElements)
+                foreach (FEMesh mesh in assignedElements)
                 {
-                    assignedFEMeshes.Add(mesh.AdapterId<string>(typeof(MidasCivilId)));
+                    List<FEMeshFace> faces = mesh.Faces;
+                    foreach (FEMeshFace face in faces)
+                    {
+                        assignedFEMeshes.Add(face.AdapterId<string>(typeof(MidasCivilId)));
+                    }
                 }
 
                 List<double> loadVectors = new List<double> { areaUniformlyDistributedLoad.Pressure.X,


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #296 

<!-- Add short description of what has been fixed -->
Fixes bug where loads were not being applied to all `FEMeshFace` when an `FEMesh` with multiple `FEMeshFaces` was pushed to MidasCivil.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23296_Area_Loading/GenericPushGeometryToMidasScript.gh?csf=1&web=1&e=MGdA95