### PR TITLE
Added create/read support for AreaDifferentialTemperatureLoad

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Create.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Create.cs
@@ -104,6 +104,9 @@ namespace BH.Adapter.MidasCivil
                         case "BH.oM.Structure.Loads.AreaUniformTemperatureLoad":
                             success = CreateCollection(objects as IEnumerable<AreaUniformTemperatureLoad>);
                             break;
+                        case "BH.oM.Structure.Loads.AreaDifferentialTemperatureLoad":
+                            success = CreateCollection(objects as IEnumerable<AreaDifferentialTemperatureLoad>);
+                            break;
                         case "BH.oM.Structure.Loads.PointDisplacement":
                             success = CreateCollection(objects as IEnumerable<PointDisplacement>);
                             break;

--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaDifferentialTemperatureLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaDifferentialTemperatureLoad.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Text;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Elements;
+using BH.oM.Geometry;
+using System.Collections.Generic;
+using System.IO;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Reflection;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+    {
+        public bool CreateCollection(IEnumerable<AreaDifferentialTemperatureLoad> areaDifferentialTemperatureLoads)
+        {
+            string loadGroupPath = CreateSectionFile("LOAD-GROUP");
+
+            foreach (AreaDifferentialTemperatureLoad areaDifferentialTemperatureLoad in areaDifferentialTemperatureLoads)
+            {
+                StringBuilder midasTemperatureLoads = new StringBuilder();
+                string feMeshLoadPath = CreateSectionFile(areaDifferentialTemperatureLoad.Loadcase.Name + "\\THERGRAD");
+                string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(areaDifferentialTemperatureLoad);
+                List<IAreaElement> assignedElements = areaDifferentialTemperatureLoad.Objects.Elements;
+                List<string> assignedFEMeshes = new List<string>();
+                AreaUniformTemperatureLoad areaUniformTemperatureLoad = new AreaUniformTemperatureLoad();
+                areaUniformTemperatureLoad.TemperatureChange = (areaDifferentialTemperatureLoad.TemperatureProfile[0] - areaDifferentialTemperatureLoad.TemperatureProfile[1]) / 2 + areaDifferentialTemperatureLoad.TemperatureProfile[1];
+                areaUniformTemperatureLoad.Name = areaDifferentialTemperatureLoad.Name;
+                areaUniformTemperatureLoad.Objects = areaDifferentialTemperatureLoad.Objects;
+                areaUniformTemperatureLoad.Loadcase = areaDifferentialTemperatureLoad.Loadcase;
+                Compute.RecordWarning("Please note the AreaDifferentialTemperatureLoad is input to MidasCivil as a Temperature Gradient and an Element Temperature Load. \n Any AreaTemperatureLoads should be pushed in a separate Loadcase to avoid errors when pulling AreaDifferentialTemperatureLoads.");
+                CreateCollection(new List<AreaUniformTemperatureLoad>() { areaUniformTemperatureLoad });
+                foreach (FEMesh mesh in assignedElements)
+                {
+                    List<FEMeshFace> faces = mesh.Faces;
+                    foreach (FEMeshFace face in faces)
+                    {
+                        assignedFEMeshes.Add(face.AdapterId<string>(typeof(MidasCivilId)));
+                    }
+                }
+                foreach (string assignedFEMesh in assignedFEMeshes)
+                {
+                    midasTemperatureLoads.AppendLine(Adapters.MidasCivil.Convert.FromAreaDifferentialTemperatureLoad(areaDifferentialTemperatureLoad, assignedFEMesh, m_temperatureUnit));
+                }
+                CompareLoadGroup(midasLoadGroup, loadGroupPath);
+                RemoveEndOfDataString(feMeshLoadPath);
+                File.AppendAllText(feMeshLoadPath, midasTemperatureLoads.ToString());
+            }
+            return true;
+        }
+    }
+}

--- a/MidasCivil_Adapter/CRUD/Read/Loads/AreaDifferentialTemperatureLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/AreaDifferentialTemperatureLoad.cs
@@ -1,0 +1,126 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Elements;
+using BH.Engine.Reflection;
+
+namespace BH.Adapter.MidasCivil
+{
+    public partial class MidasCivilAdapter
+    {
+        private List<ILoad> ReadAreaDifferentialTemperatureLoads(List<string> ids = null)
+        {
+            List<ILoad> bhomAreaDifferentialTemperatureLoads = new List<ILoad>();
+
+            List<Loadcase> bhomLoadcases = ReadLoadcases();
+            Dictionary<string, Loadcase> loadcaseDictionary = bhomLoadcases.ToDictionary(
+                        x => x.Name);
+
+            string[] loadcaseFolders = Directory.GetDirectories(m_directory + "\\TextFiles");
+
+            foreach (string loadcaseFolder in loadcaseFolders)
+            {
+                string loadcase = Path.GetFileName(loadcaseFolder);
+                List<string> areaDifferentialTemperatureLoadText = GetSectionText(loadcase + "\\THERGRAD");
+                List<string> areaUniformTemperatureLoadText = GetSectionText(loadcase + "\\ELTEMPER");
+                List<string> feMeshComparison = new List<string>();
+                List<string> loadedFEMeshes = new List<string>();
+
+                if (areaDifferentialTemperatureLoadText.Count != 0)
+                {
+                    List<string> areaDifferentialTempatureElements = areaDifferentialTemperatureLoadText.Select(x => x.Split(',')[0]).ToList();
+                    List<string> areaUniformTempatureElements = areaUniformTemperatureLoadText.Select(x => x.Split(',')[0]).ToList();
+                    for (int i = 0; i < areaDifferentialTempatureElements.Count; i++)
+                    {
+                        List<string> differentialDelimitted = areaDifferentialTemperatureLoadText[i].Split(',').ToList();
+                        loadedFEMeshes.Add(areaDifferentialTempatureElements[i].Trim());
+                        differentialDelimitted.RemoveAt(0);
+                        if (areaUniformTempatureElements.Count != 0)
+                        {
+                            if (areaDifferentialTempatureElements[i] == areaUniformTempatureElements[i])
+                            {
+                                List<string> globalDelimitted = areaUniformTemperatureLoadText[i].Split(',').ToList();
+                                //When an area uniform temp offset load is detected,  it is added as an additional string to the area diff. temp list of string.
+                                differentialDelimitted.Add(globalDelimitted[1].Trim());
+                            }
+                            else
+                            {
+
+                                Compute.RecordWarning("No Area Uniform Temperature Load is integrated as part of the Area Differential Temperature Load at Element number "
+                                    + areaDifferentialTempatureElements[i].Trim().ToString() + " \n due to the two loads are assigned to different element." +
+                                " \n Area Differential Temperature load will be applied at the centroid of the cross section at Element number "
+                                + areaDifferentialTempatureElements[i].Trim().ToString());
+                                differentialDelimitted.Add(string.Format("0"));
+                            }
+                        }
+                        else
+                        {
+                            Compute.RecordWarning("No Area Uniform Temperature Load is detected at Element number " 
+                            + areaDifferentialTempatureElements[i].Trim().ToString()+
+                            ". \n Area Differential Temperature load will be applied at the centroid of the cross section at Element number" 
+                            + areaDifferentialTempatureElements[i].Trim().ToString());
+                            differentialDelimitted.Add(string.Format("0"));
+                        }
+                        feMeshComparison.Add(String.Join(",", differentialDelimitted));
+                    }
+                    if (feMeshComparison.Count != 0)
+                    {
+                        List<FEMesh> bhomMeshes = ReadFEMeshes();
+                        Dictionary<string, FEMesh> feMeshDictionary = bhomMeshes.ToDictionary(
+                                                                    x => x.AdapterId<string>(typeof(MidasCivilId)));
+                        List<string> distinctFEMeshLoads = feMeshComparison.Distinct().ToList();
+                        int i = 1;
+                        foreach (string distinctFEMeshLoad in distinctFEMeshLoads)
+                        {
+                            List<int> indexMatches = feMeshComparison.Select((meshload, index) => new { meshload, index })
+                                                       .Where(x => string.Equals(x.meshload, distinctFEMeshLoad))
+                                                       .Select(x => x.index)
+                                                       .ToList();
+                            List<string> matchingFEMeshes = new List<string>();
+                            indexMatches.ForEach(x => matchingFEMeshes.Add(loadedFEMeshes[x]));
+                            AreaDifferentialTemperatureLoad bhomAreaDifferentialTemperatureLoad =
+                                Adapters.MidasCivil.Convert.ToAreaDifferentialTemperatureLoad(
+                                    distinctFEMeshLoad, matchingFEMeshes, loadcase, loadcaseDictionary, feMeshDictionary, i, m_temperatureUnit);
+
+                            if (bhomAreaDifferentialTemperatureLoad != null)
+                                bhomAreaDifferentialTemperatureLoads.Add(bhomAreaDifferentialTemperatureLoad);
+
+                            if ((string.IsNullOrWhiteSpace(distinctFEMeshLoad.Split(',')[1].ToString())))
+                            {
+                                i = i + 1;
+                            }
+                        }
+
+                    }
+                }
+            }
+            return bhomAreaDifferentialTemperatureLoads;
+        }
+    }
+}

--- a/MidasCivil_Adapter/CRUD/Read/Loads/ReadLoad.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Loads/ReadLoad.cs
@@ -56,6 +56,9 @@ namespace BH.Adapter.MidasCivil
                 case "AreaUniformTemperatureLoad":
                     readLoads = ReadAreaUniformTemperatureLoads(ids as dynamic);
                     break;
+                case "AreaDifferentialTemperatureLoad":
+                    readLoads = ReadAreaDifferentialTemperatureLoads(ids as dynamic);
+                    break;
                 case "PointDisplacement":
                     readLoads = ReadPointDisplacements(ids as dynamic);
                     break;

--- a/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToAreaDifferentialTemperatureLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Loads/ToAreaDifferentialTemperatureLoad.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using BH.oM.Adapters.MidasCivil;
+using BH.Engine.Adapter;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.Elements;
+
+namespace BH.Adapter.Adapters.MidasCivil
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static AreaDifferentialTemperatureLoad ToAreaDifferentialTemperatureLoad(string temperatureLoad, List<string> associatedFEMeshes, string loadcase,
+            Dictionary<string, Loadcase> loadcaseDictionary, Dictionary<string, FEMesh> feMeshDictionary, int count, string temperatureUnit)
+        {
+            List<string> delimitted = new List<string>(temperatureLoad.Split(','));
+            List<FEMesh> bhomAssociatedFEMeshes = new List<FEMesh>();
+            Loadcase bhomLoadcase;
+            loadcaseDictionary.TryGetValue(loadcase, out bhomLoadcase);
+            foreach (string associatedFEMesh in associatedFEMeshes)
+            {
+                if (feMeshDictionary.ContainsKey(associatedFEMesh))
+                {
+                    FEMesh bhomAssociatedFEMesh;
+                    feMeshDictionary.TryGetValue(associatedFEMesh, out bhomAssociatedFEMesh);
+                    bhomAssociatedFEMeshes.Add(bhomAssociatedFEMesh);
+                }
+            }
+            double temperature = double.Parse(delimitted[1].Trim());
+            double temperatureOffset = double.Parse(delimitted[5].Trim());
+            double topTemperature = temperature / 2 + temperatureOffset;
+            double botTemperature = -temperature / 2 + temperatureOffset;
+            string name;
+            if (string.IsNullOrWhiteSpace(delimitted[4]))
+            {
+                name = "ADTL" + count;
+            }
+            else
+            {
+                name = delimitted[4].Trim();
+            }
+            if (bhomAssociatedFEMeshes.Count != 0)
+            {
+                AreaDifferentialTemperatureLoad bhomAreaDifferentialTemperatureLoad = Engine.Structure.Create.AreaDifferentialTemperatureLoad(
+                    bhomLoadcase, topTemperature.DeltaTemperatureToSI(temperatureUnit), botTemperature.DeltaTemperatureToSI(temperatureUnit),
+                    bhomAssociatedFEMeshes, name);
+                bhomAreaDifferentialTemperatureLoad.SetAdapterId(typeof(MidasCivilId), bhomAreaDifferentialTemperatureLoad.Name);
+                return bhomAreaDifferentialTemperatureLoad;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+    }
+}
+
+

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaDifferentialTemperatureLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaDifferentialTemperatureLoad.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Structure.Loads;
+
+namespace BH.Adapter.Adapters.MidasCivil
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static string FromAreaDifferentialTemperatureLoad(this AreaDifferentialTemperatureLoad temperatureProfile, string assignedFEMesh, string temperatureUnit)
+        {
+            string midasFEMeshLoad = null;
+                double temperatureDifference = temperatureProfile.TemperatureProfile[0].DeltaTemperatureToSI(temperatureUnit) - temperatureProfile.TemperatureProfile[1].DeltaTemperatureToSI(temperatureUnit);
+                midasFEMeshLoad = assignedFEMesh + ",2," + temperatureDifference + "," + "YES,0," +
+                temperatureProfile.Name;
+            return midasFEMeshLoad;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/MidasCivil_Adapter/MidasCivil_Adapter.csproj
+++ b/MidasCivil_Adapter/MidasCivil_Adapter.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Convert\ToBHoM\Elements\ToNode.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToPanel.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToRigidLink.cs" />
+    <Compile Include="Convert\ToBHoM\Loads\ToAreaDifferentialTemperatureLoad.cs" />
     <Compile Include="Convert\ToBHoM\Loads\ToAreaUniformTemperatureLoad.cs" />
     <Compile Include="Convert\ToBHoM\Loads\ToAreaUniformlyDistributedLoad.cs" />
     <Compile Include="Convert\ToBHoM\Loads\ToBarDifferentialTemperatureLoad.cs" />
@@ -164,6 +165,7 @@
     <Compile Include="Convert\ToMidasCivil\Elements\FromFEMesh.cs" />
     <Compile Include="Convert\ToMidasCivil\Elements\FromNode.cs" />
     <Compile Include="Convert\ToMidasCivil\Elements\FromRigidLink.cs" />
+    <Compile Include="Convert\ToMidasCivil\Loads\FromAreaDifferentialTemperatureLoad.cs" />
     <Compile Include="Convert\ToMidasCivil\Loads\FromAreaUniformTemperatureLoad.cs" />
     <Compile Include="Convert\ToMidasCivil\Loads\FromAreaUniformlyDistributedLoad.cs" />
     <Compile Include="Convert\ToMidasCivil\Loads\FromBarDifferentialTemperatureLoad.cs" />
@@ -218,6 +220,7 @@
     <Compile Include="CRUD\Create\Elements\RigidLink.cs" />
     <Compile Include="CRUD\Create\Elements\Element.cs" />
     <Compile Include="CRUD\Create\Elements\Node.cs" />
+    <Compile Include="CRUD\Create\Loads\AreaDifferentialTemperatureLoad.cs" />
     <Compile Include="CRUD\Create\Loads\BarDifferentialTemperatureLoad.cs" />
     <Compile Include="CRUD\Create\Loads\Loadcase.cs" />
     <Compile Include="CRUD\Create\Loads\AreaUniformTemperatureLoads.cs" />
@@ -254,6 +257,7 @@
     <Compile Include="CRUD\Delete\Properties\BarReleases.cs" />
     <Compile Include="CRUD\Delete\Properties\SectionProperties.cs" />
     <Compile Include="CRUD\Delete\Properties\SurfaceProperties.cs" />
+    <Compile Include="CRUD\Read\Loads\AreaDifferentialTemperatureLoad.cs" />
     <Compile Include="CRUD\Read\Loads\BarDifferentialTemperatureLoad.cs" />
     <Compile Include="CRUD\Read\Results\BarResults.cs" />
     <Compile Include="CRUD\Read\Results\MeshResults.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #271 

<!-- Add short description of what has been fixed -->

This is the same PR as #292. Please go to #292 for previous comments.
Added support for writing `AreaDifferentialTemperatureLoad`.
Added support for reading `AreaDifferentialTemperatureLoad`.

Please note that this feature is only  supports input for `TopPosition` and `BottomPosition`. In Midas, the `AreaDifferentialTemperatureLoad` is inputted as a combination of `ElementTemperatures` and `TemperatureGradient`.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?cid=506a082e%2Daf0c%2D43ad%2D8fb5%2D4505bb1e26bb&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FArchive%2FMidasCivil%5FToolkit%2FMidasCivil%5FToolkit%2D%23271

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added support for writing `AreaDifferentialTemperatureLoad`.
- Added support for reading `AreaDifferentialTemperatureLoad`.