### PR TITLE
Fix bug in CompareLoadGroup

### DIFF
--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaDifferentialTemperatureLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaDifferentialTemperatureLoad.cs
@@ -34,8 +34,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         {
             string midasFEMeshLoad = null;
                 double temperatureDifference = temperatureProfile.TemperatureProfile[0].DeltaTemperatureToSI(temperatureUnit) - temperatureProfile.TemperatureProfile[1].DeltaTemperatureToSI(temperatureUnit);
-                midasFEMeshLoad = assignedFEMesh + ",2," + temperatureDifference + "," + "YES,0," +
-                temperatureProfile.Name;
+                midasFEMeshLoad = assignedFEMesh + ",2," + temperatureDifference + "," + "YES,0," + temperatureProfile.Name;
             return midasFEMeshLoad;
         }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromBarDifferentialTemperatureLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromBarDifferentialTemperatureLoad.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             double presetWidth = sectionProperty.Area / depth;
             double temperatureProfileCount = load.TemperatureProfile.Keys.Count - 1;
-            string firstLine = ids.Trim() + "," + loadDirection + ",Bot ," + temperatureProfileCount + ", ," + "No";
+            string firstLine = ids.Trim() + "," + loadDirection + ",Bot ," + temperatureProfileCount + load.Name + "No";
             List<string> midasBarLoad = new List<string>();
             midasBarLoad.Add(firstLine);
             for (int i = 1; i < load.TemperatureProfile.Keys.Count; i++)

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromBarDifferentialTemperatureLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromBarDifferentialTemperatureLoad.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             }
             double presetWidth = sectionProperty.Area / depth;
             double temperatureProfileCount = load.TemperatureProfile.Keys.Count - 1;
-            string firstLine = ids.Trim() + "," + loadDirection + ",Bot ," + temperatureProfileCount + load.Name + "No";
+            string firstLine = ids.Trim() + "," + loadDirection + ",Bot ," + temperatureProfileCount + "," + load.Name + "," + "No";
             List<string> midasBarLoad = new List<string>();
             midasBarLoad.Add(firstLine);
             for (int i = 1; i < load.TemperatureProfile.Keys.Count; i++)

--- a/MidasCivil_Adapter/PrivateHelpers/CompareLoadGroup.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/CompareLoadGroup.cs
@@ -21,6 +21,7 @@
  */
 
 using System.IO;
+using System.Linq;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -35,14 +36,8 @@ namespace BH.Adapter.MidasCivil
             string[] loadGroups = File.ReadAllLines(path);
             bool existing = false;
 
-            for (int i = 0; i < loadGroups.Length; i++)
-            {
-                if (loadGroups[i].Contains(loadGroup))
-                {
-                    existing = true;
-                    break;
-                }
-            }
+            if (loadGroups.Any(x => x == loadGroup))
+                existing = true;
 
             if (!existing)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #307 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/Installers/Scripts/BuroHappold_BHoM_v4.2/Structures%20-%20Create%20read%20loads?csf=1&web=1&e=IbHwj6

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug where loads with names that were contained in load names already pushed would not be pushed. For example a `barPointLoad.Name = BarPointLoad-1` is pushed, trying to push `pointLoad.Name = PointLoad-1` would not succeed,
- Fixed a bug where the `BarDifferentialTemperatureLoad` was not assigned a Load Group in MidasCivil corresponding to its name
