### PR TITLE
Fixed sign convention and units bug

### DIFF
--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
@@ -55,10 +55,13 @@ namespace BH.Adapter.Adapters.MidasCivil
                     webSpacing = System.Convert.ToDouble(sectionProfile[4]).LengthToSI(lengthUnit);
                     webThickness = System.Convert.ToDouble(sectionProfile[2]).LengthToSI(lengthUnit);
                     double corbel;
-                    if (webSpacing < Tolerance.Distance || System.Math.Abs(width / 2 - webSpacing / 2 - webThickness / 2) < Tolerance.Distance)
+                    if (webSpacing < Tolerance.Distance || System.Math.Abs(width - webSpacing - webThickness) < Tolerance.Distance)
                         corbel = 0;
                     else
-                        corbel = (width / 2 - webSpacing / 2 - webThickness / 2).LengthToSI(lengthUnit);
+                    {
+                        corbel = (width / 2 - webSpacing / 2 - webThickness / 2);
+                        width = (webSpacing + webThickness);
+                    }
 
                     topFlangeThickness = System.Convert.ToDouble(sectionProfile[3]).LengthToSI(lengthUnit);
                     bottomFlangeThickness = System.Convert.ToDouble(sectionProfile[5]).LengthToSI(lengthUnit);

--- a/MidasCivil_Adapter/Convert/ToBHoM/Results/ToBarForce.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Results/ToBarForce.cs
@@ -54,8 +54,8 @@ namespace BH.Adapter.MidasCivil
                 System.Convert.ToDouble(delimitted[12]).ForceToSI(forceUnit),
                 System.Convert.ToDouble(delimitted[13]).ForceToSI(forceUnit),
                 System.Convert.ToDouble(delimitted[14]).MomentToSI(forceUnit, lengthUnit),
-                System.Convert.ToDouble(delimitted[15]).MomentToSI(forceUnit, lengthUnit),
-                System.Convert.ToDouble(delimitted[16]).MomentToSI(forceUnit, lengthUnit)
+                -System.Convert.ToDouble(delimitted[15]).MomentToSI(forceUnit, lengthUnit),
+                -System.Convert.ToDouble(delimitted[16]).MomentToSI(forceUnit, lengthUnit)
                 );
             return barforce;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -339,17 +339,18 @@ namespace BH.Adapter.Adapters.MidasCivil
         private static string CreateProfile(GeneralisedFabricatedBoxProfile profile, string lengthUnit)
         {
             double webSpacing = 0;
+            double flangeWidth = (profile.Width);
             if (profile.TopLeftCorbelWidth != 0 || profile.TopRightCorbelWidth != 0 || profile.BotLeftCorbelWidth != 0 || profile.BotRightCorbelWidth != 0)
             {
                 webSpacing = (profile.Width - profile.WebThickness).LengthFromSI(lengthUnit);
+                flangeWidth = (flangeWidth + profile.TopLeftCorbelWidth + profile.TopRightCorbelWidth);
+
+                Engine.Reflection.Compute.RecordWarning("MidasCivil does not support unequal corbel widths. Therefore the section width has been calculated using the TopCorbelWidths.");
             }
             string midasSectionProperty = "B, 2," +
-                profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + "," + profile.WebThickness.LengthFromSI(lengthUnit) + "," +
+                profile.Height.LengthFromSI(lengthUnit) + "," + flangeWidth.LengthFromSI(lengthUnit) + "," + profile.WebThickness.LengthFromSI(lengthUnit) + "," +
                 profile.TopFlangeThickness.LengthFromSI(lengthUnit) + "," + webSpacing + "," + profile.BotFlangeThickness.LengthFromSI(lengthUnit) +
                 ", 0, 0, 0, 0";
-
-            Engine.Reflection.Compute.RecordWarning("MidasCivil does not support unequal corbel widths. Therefore the spacing of the webs " +
-                "have been calculated using the TopLeftCorbelWidth and TopRightCorbelWidth only.");
 
             return midasSectionProperty;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -341,7 +341,7 @@ namespace BH.Adapter.Adapters.MidasCivil
             double webSpacing = 0;
             if (profile.TopLeftCorbelWidth != 0 || profile.TopRightCorbelWidth != 0 || profile.BotLeftCorbelWidth != 0 || profile.BotRightCorbelWidth != 0)
             {
-                webSpacing = (profile.Width - profile.TopLeftCorbelWidth - profile.TopRightCorbelWidth - profile.WebThickness).LengthFromSI(lengthUnit);
+                webSpacing = (profile.Width - profile.WebThickness).LengthFromSI(lengthUnit);
             }
             string midasSectionProperty = "B, 2," +
                 profile.Height.LengthFromSI(lengthUnit) + "," + profile.Width.LengthFromSI(lengthUnit) + "," + profile.WebThickness.LengthFromSI(lengthUnit) + "," +

--- a/MidasCivil_Adapter/Convert/Units/ForceToSI.cs
+++ b/MidasCivil_Adapter/Convert/Units/ForceToSI.cs
@@ -54,7 +54,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 case "KIPS":
                     return force.FromKilopoundForce();
                 default:
-                    Compute.RecordWarning("No firce unit detected, MidasCivil force unit assumed to be set to metres. Therefore no unit conversion will occur. ");
+                    Compute.RecordWarning("No force unit detected, MidasCivil force unit assumed to be set to metres. Therefore no unit conversion will occur. ");
                     break;
             }
 

--- a/MidasCivil_Adapter/Convert/Units/MomentFromSI.cs
+++ b/MidasCivil_Adapter/Convert/Units/MomentFromSI.cs
@@ -65,7 +65,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     switch (lengthUnit)
                     {
                         case "M":
-                            return moment.ToKilonewtonCentimetre();
+                            return moment.ToKilonewtonMetre();
                         case "CM":
                             return moment.ToKilonewtonCentimetre();
                         case "MM":

--- a/MidasCivil_Adapter/Convert/Units/MomentToSI.cs
+++ b/MidasCivil_Adapter/Convert/Units/MomentToSI.cs
@@ -65,7 +65,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     switch (lengthUnit)
                     {
                         case "M":
-                            return moment.FromKilonewtonCentimetre();
+                            return moment.FromKilonewtonMetre();
                         case "CM":
                             return moment.FromKilonewtonCentimetre();
                         case "MM":

--- a/MidasCivil_Adapter/Convert/Units/PressureFromSI.cs
+++ b/MidasCivil_Adapter/Convert/Units/PressureFromSI.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         case "CM":
                             return pressure.ToNewtonPerSquareCentimetre();
                         case "MM":
-                            return pressure.ToNewtonPerMillimetre();
+                            return pressure.ToNewtonPerSquareMillimetre();
                         case "FT":
                             throw new Exception("No conversion method found for" + forceUnit + " " + lengthUnit);
                         case "IN":
@@ -82,7 +82,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     switch (lengthUnit)
                     {
                         case "M":
-                            return pressure.ToKilogramForcePerMetre();
+                            return pressure.ToKilogramForcePerSquareMetre();
                         case "CM":
                             return pressure.ToKilogramForcePerSquareCentimetre();
                         case "MM":

--- a/MidasCivil_Adapter/Convert/Units/PressureToSI.cs
+++ b/MidasCivil_Adapter/Convert/Units/PressureToSI.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         case "CM":
                             return pressure.FromNewtonPerSquareCentimetre();
                         case "MM":
-                            return pressure.FromNewtonPerMillimetre();
+                            return pressure.FromNewtonPerSquareMillimetre();
                         case "FT":
                             throw new Exception("No conversion method found for" + forceUnit + " " + lengthUnit);
                         case "IN":
@@ -82,7 +82,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                     switch (lengthUnit)
                     {
                         case "M":
-                            return pressure.FromKilogramForcePerMetre();
+                            return pressure.FromKilogramForcePerSquareMetre();
                         case "CM":
                             return pressure.FromKilogramForcePerSquareCentimetre();
                         case "MM":


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #288
Closes #311 
Closes #313
Closes #314  
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Results unit conversion and moment sign convention](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23288-Fixed%20sign%20convention%20and%20units%20bug?csf=1&web=1&e=KW9Ug2)
[Pushing/Pulling GeneralisedFabricatedBoxSection](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23313-Pushing%20corbel%20width%20on%20box%20sections?csf=1&web=1&e=PrvxCe)
[Checking box sections with different parameters can still be pulled from MidasCivil](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23304-Corbel%20width%20bug%20on%20box%20sections?csf=1&web=1&e=0zpZXx)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug where results were not complying with the BHoM sign convention, particularly the moments (My and Mz)
- Fixed a bug where unit conversions when pulling and pushing results for moments and pressures were incorrect.
- Fixed a bug where a negative web spacing was pushed for a `GeneralisedFabricatedBoxProfile`
- Fixed a bug where an incorrect flange width was pulled for a `GeneralisedFabricatedBoxProfile`
### Additional comments
<!-- As required -->