### PR TITLE
Add support for MidasCivil 2022 

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
@@ -71,7 +71,7 @@ namespace BH.Adapter.MidasCivil
 
                         foreach (string assignedFEMesh in assignedFEMeshes)
                         {
-                            midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(areaUniformlyDistributedLoad, assignedFEMesh, m_forceUnit, m_lengthUnit));
+                            midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(areaUniformlyDistributedLoad, assignedFEMesh, m_midasCivilVersion, m_forceUnit, m_lengthUnit));
                         }
                     }
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Loads/PointForce.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/PointForce.cs
@@ -49,7 +49,7 @@ namespace BH.Adapter.MidasCivil
 
                 foreach (string assignedNode in assignedNodes)
                 {
-                    midasPointLoads.Add(Adapters.MidasCivil.Convert.FromPointLoad(PointLoad, assignedNode, m_forceUnit, m_lengthUnit));
+                    midasPointLoads.Add(Adapters.MidasCivil.Convert.FromPointLoad(PointLoad, assignedNode, m_midasCivilVersion, m_forceUnit, m_lengthUnit));
                 }
 
                 RemoveEndOfDataString(PointLoadPath);

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -73,6 +73,9 @@ namespace BH.Adapter.Adapters.MidasCivil
                 {
                     switch (version)
                     {
+                        case "9.1.0":
+                        case "9.0.5":
+                        case "9.0.0":
                         case "8.9.5":
                         case "8.9.0":
                         case "8.8.5":

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
@@ -40,6 +40,9 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             switch (version)
             {
+                case "9.1.0":
+                case "9.0.5":
+                case "9.0.0":
                 case "8.9.5":
                 case "8.9.0":
                     constantThickness = new ConstantThickness

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaUniformlyDistributedLoad.cs
@@ -45,13 +45,13 @@ namespace BH.Adapter.Adapters.MidasCivil
             switch (version)
             {
                 case "9.1.0":
-                    assignedFEMesh = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
+                    midasFEMeshLoad = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
                                 ", 0, 0, 0, " + FromLoadProjection(femeshLoad.Projected) + ", " +
                                 FromVectorDirection(femeshLoad.Pressure, direction).PressureFromSI(forceUnit, lengthUnit).ToString() +
                                 ", 0, 0, 0, 0, " + femeshLoad.Name + ",0";
                     break;
                 default:
-                    assignedFEMesh = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
+                    midasFEMeshLoad = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
                     ", 0, 0, 0, " + FromLoadProjection(femeshLoad.Projected) + ", " +
                     FromVectorDirection(femeshLoad.Pressure, direction).PressureFromSI(forceUnit, lengthUnit).ToString() +
                     ", 0, 0, 0, 0, " + femeshLoad.Name;

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaUniformlyDistributedLoad.cs
@@ -36,13 +36,29 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromAreaUniformlyDistributedLoad(this AreaUniformlyDistributedLoad femeshLoad, string assignedFEMesh, string forceUnit, string lengthUnit)
+        public static string FromAreaUniformlyDistributedLoad(this AreaUniformlyDistributedLoad femeshLoad, string assignedFEMesh, string version,
+            string forceUnit, string lengthUnit)
         {
             string direction = FromVector(femeshLoad.Pressure);
-            string midasFEMeshLoad = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
-                                    ", 0, 0, 0, " + FromLoadProjection(femeshLoad.Projected) + ", " +
-                                    FromVectorDirection(femeshLoad.Pressure, direction).PressureFromSI(forceUnit, lengthUnit).ToString() +
-                                    ", 0, 0, 0, 0, " + femeshLoad.Name;
+            string midasFEMeshLoad = "";
+
+            switch (version)
+            {
+                case "9.1.0":
+                    assignedFEMesh = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
+                                ", 0, 0, 0, " + FromLoadProjection(femeshLoad.Projected) + ", " +
+                                FromVectorDirection(femeshLoad.Pressure, direction).PressureFromSI(forceUnit, lengthUnit).ToString() +
+                                ", 0, 0, 0, 0, " + femeshLoad.Name + ",0";
+                    break;
+                default:
+                    assignedFEMesh = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
+                    ", 0, 0, 0, " + FromLoadProjection(femeshLoad.Projected) + ", " +
+                    FromVectorDirection(femeshLoad.Pressure, direction).PressureFromSI(forceUnit, lengthUnit).ToString() +
+                    ", 0, 0, 0, 0, " + femeshLoad.Name;
+                    break;
+            }
+
+
 
             return midasFEMeshLoad;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromLoadCombination.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromLoadCombination.cs
@@ -39,6 +39,9 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             switch (version)
             {
+                case "9.1.0":
+                case "9.0.5":
+                case "9.0.0":
                 case "8.9.5":
                 case "8.9.0":
                 case "8.8.5":

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromPointForce.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromPointForce.cs
@@ -31,15 +31,33 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string FromPointLoad(this PointLoad pointLoad, string assignedNode, string forceUnit, string lengthUnit)
+        public static string FromPointLoad(this PointLoad pointLoad, string assignedNode, string version, string forceUnit, string lengthUnit)
         {
-            string midasPointLoad = assignedNode + "," + pointLoad.Force.X.ForceFromSI(forceUnit).ToString() +
+            string midasPointLoad = "";
+
+            switch(version)
+            {
+                case "9.1.0":
+                    midasPointLoad = assignedNode + "," + pointLoad.Force.X.ForceFromSI(forceUnit).ToString() +
                                                     "," + pointLoad.Force.Y.ForceFromSI(forceUnit).ToString() +
                                                     "," + pointLoad.Force.Z.ForceFromSI(forceUnit).ToString() +
                                                     "," + pointLoad.Moment.X.MomentFromSI(forceUnit, lengthUnit).ToString() +
                                                     "," + pointLoad.Moment.Y.MomentFromSI(forceUnit, lengthUnit).ToString() +
                                                     "," + pointLoad.Moment.Z.MomentFromSI(forceUnit, lengthUnit).ToString() +
-                                                    "," + pointLoad.Name;
+                                                    "," + pointLoad.Name + ",";
+                    break;
+                default:
+                    midasPointLoad = assignedNode + "," + pointLoad.Force.X.ForceFromSI(forceUnit).ToString() +
+                                "," + pointLoad.Force.Y.ForceFromSI(forceUnit).ToString() +
+                                "," + pointLoad.Force.Z.ForceFromSI(forceUnit).ToString() +
+                                "," + pointLoad.Moment.X.MomentFromSI(forceUnit, lengthUnit).ToString() +
+                                "," + pointLoad.Moment.Y.MomentFromSI(forceUnit, lengthUnit).ToString() +
+                                "," + pointLoad.Moment.Z.MomentFromSI(forceUnit, lengthUnit).ToString() +
+                                "," + pointLoad.Name;
+                    break;
+
+            }
+
             return midasPointLoad;
         }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSpring.cs
@@ -43,6 +43,9 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             switch (version)
             {
+                case "9.1.0":
+                case "9.0.5":
+                case "9.0.0":
                 case "8.9.5":
                 case "8.9.0":
                 case "8.8.5":

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
@@ -57,6 +57,9 @@ namespace BH.Adapter.Adapters.MidasCivil
                 string midasSurfaceProperty = "";
                 switch (version)
                 {
+                    case "9.1.0":
+                    case "9.0.5":
+                    case "9.0.0":
                     case "8.9.5":
                     case "8.9.0":
                         midasSurfaceProperty =

--- a/MidasCivil_Adapter/PrivateHelpers/GetPropertyAssignments.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/GetPropertyAssignments.cs
@@ -67,6 +67,9 @@ namespace BH.Adapter.MidasCivil
                     case "SPRING":
                         switch (m_midasCivilVersion)
                         {
+                            case "9.1.0":
+                            case "9.0.5":
+                            case "9.0.0":
                             case "8.9.5":
                             case "8.9.0":
                             case "8.8.5":


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #334 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23335-Add%20support%20for%20MidasCivil%202022%20v2.2?csf=1&web=1&e=0l7Zcw

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
-  Added support for MidasCivil 2021 (all versions) to MidasCivil 2022 (up to v2.1) which only impacts `SurfaceProperty`, `Constaint6DOF` and `LoadCombination`
- Fixed bug where `AreaUniformlyDistributedLoads` were not being pushed as the parsing had been amended in 9.1.0.

### Additional comments
<!-- As required -->