### PR TITLE
Add support for pushing and pulling of custom sections

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -23,6 +23,7 @@
 using System.IO;
 using System.Collections.Generic;
 using BH.oM.Structure.SectionProperties;
+using BH.oM.Spatial.ShapeProfiles;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -34,17 +35,61 @@ namespace BH.Adapter.MidasCivil
 
         private bool CreateCollection(IEnumerable<ISectionProperty> sectionProperties)
         {
-            string path = CreateSectionFile("SECTION");
+            string sectionPath = CreateSectionFile("SECTION");
+            string pscSectionPath = CreateSectionFile("SECT-PSCVALUE");
             List<string> midasSectionProperties = new List<string>();
+            List<string> midasPSCSectionProperties = new List<string>();
 
             foreach (ISectionProperty sectionProperty in sectionProperties)
             {
                 List<string> midasSectionProperty = Adapters.MidasCivil.Convert.FromSectionProperty(sectionProperty, m_lengthUnit, m_sectionPropertyCharacterLimit);
                 if (midasSectionProperty != null)
-                    midasSectionProperties.AddRange(midasSectionProperty);
+                {
+                    if (sectionProperty is SteelSection)
+                    {
+                        SteelSection steelSection = (SteelSection)sectionProperty;
+                        if(steelSection.SectionProfile is FreeFormProfile)
+                            midasPSCSectionProperties.AddRange(midasSectionProperty);
+                        else
+                            midasSectionProperties.AddRange(midasSectionProperty);
+                    }
+                    if (sectionProperty is ConcreteSection)
+                    {
+                        ConcreteSection concreteSection = (ConcreteSection)sectionProperty;
+                        if (concreteSection.SectionProfile is FreeFormProfile)
+                            midasPSCSectionProperties.AddRange(midasSectionProperty);
+                        else
+                            midasSectionProperties.AddRange(midasSectionProperty);
+                    }
+                    if (sectionProperty is TimberSection)
+                    {
+                        TimberSection timberSection = (TimberSection)sectionProperty;
+                        if (timberSection.SectionProfile is FreeFormProfile)
+                            midasPSCSectionProperties.AddRange(midasSectionProperty);
+                        else
+                            midasSectionProperties.AddRange(midasSectionProperty);
+                    }
+                    if (sectionProperty is AluminiumSection)
+                    {
+                        AluminiumSection aluminiumSection = (AluminiumSection)sectionProperty;
+                        if (aluminiumSection.SectionProfile is FreeFormProfile)
+                            midasPSCSectionProperties.AddRange(midasSectionProperty);
+                        else
+                            midasSectionProperties.AddRange(midasSectionProperty);
+                    }
+                    else
+                    {
+                        GenericSection steelSection = (GenericSection)sectionProperty;
+                        if (steelSection.SectionProfile is FreeFormProfile)
+                            midasPSCSectionProperties.AddRange(midasSectionProperty);
+                        else
+                            midasSectionProperties.AddRange(midasSectionProperty);
+                    }
+                }
             }
 
-            File.AppendAllLines(path, midasSectionProperties);
+            File.AppendAllLines(sectionPath, midasSectionProperties);
+            File.AppendAllLines(pscSectionPath, midasPSCSectionProperties);
 
             return true;
         }

--- a/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.MidasCivil
                     if (sectionProperty is SteelSection)
                     {
                         SteelSection steelSection = (SteelSection)sectionProperty;
-                        if(steelSection.SectionProfile is FreeFormProfile)
+                        if (steelSection.SectionProfile is FreeFormProfile)
                             midasPSCSectionProperties.AddRange(midasSectionProperty);
                         else
                             midasSectionProperties.AddRange(midasSectionProperty);

--- a/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.MidasCivil
                         else
                             midasSectionProperties.AddRange(midasSectionProperty);
                     }
-                    if (sectionProperty is ConcreteSection)
+                    else if (sectionProperty is ConcreteSection)
                     {
                         ConcreteSection concreteSection = (ConcreteSection)sectionProperty;
                         if (concreteSection.SectionProfile is FreeFormProfile)
@@ -61,7 +61,7 @@ namespace BH.Adapter.MidasCivil
                         else
                             midasSectionProperties.AddRange(midasSectionProperty);
                     }
-                    if (sectionProperty is TimberSection)
+                    else if (sectionProperty is TimberSection)
                     {
                         TimberSection timberSection = (TimberSection)sectionProperty;
                         if (timberSection.SectionProfile is FreeFormProfile)
@@ -69,7 +69,7 @@ namespace BH.Adapter.MidasCivil
                         else
                             midasSectionProperties.AddRange(midasSectionProperty);
                     }
-                    if (sectionProperty is AluminiumSection)
+                    else if (sectionProperty is AluminiumSection)
                     {
                         AluminiumSection aluminiumSection = (AluminiumSection)sectionProperty;
                         if (aluminiumSection.SectionProfile is FreeFormProfile)

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -113,7 +113,8 @@ namespace BH.Adapter.MidasCivil
             List<string> pscSectionProperties = GetSectionText("SECT-PSCVALUE");
             for (int i = 0; i < pscSectionProperties.Count; i++)
             {
-                int iEnd = pscSectionProperties.IndexOf("SECT", i + 1);
+                int iEnd = pscSectionProperties.FindIndex(i + 1, x => x.Contains("SECT"));
+
                 if (iEnd == -1)
                     iEnd = pscSectionProperties.Count() - 1;
 
@@ -129,8 +130,8 @@ namespace BH.Adapter.MidasCivil
                     string sectionProperties2 = pscSectionProperty[i + 2];
                     string sectionProperties3 = pscSectionProperty[i + 3];
 
-                    int iOPolyStart = pscSectionProperty.IndexOf("OPOLY", i);
-                    int iOPolyEnd = pscSectionProperty.IndexOf("IPOLY", i) - 1;
+                    int iOPolyStart = pscSectionProperty.FindIndex(i, x => x.Contains("OPOLY"));
+                    int iOPolyEnd = pscSectionProperty.FindIndex(i, x => x.Contains("IPOLY")) - 1;
 
                     if (iOPolyEnd == -1)
                         iOPolyEnd = pscSectionProperty.Count() - 1;
@@ -143,15 +144,15 @@ namespace BH.Adapter.MidasCivil
                     if(pscSectionProperty.Contains("IPOLY"))
                     {
                         int iPolyStart = iOPolyEnd + 1;
-                        int iPolyEnd = pscSectionProperty.IndexOf("IPOLY", iPolyStart + 1);
+                        int iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY"));
 
                         // Iterate through each IPoly 
-                        while(!(iPolyEnd == -1))
+                        while (!(iPolyEnd == -1))
                         {
                             polys.Add(new Polyline() { ControlPoints = ParsePoints(pscSectionProperty, iPolyStart, iPolyEnd, "IPOLY") });
 
                             iPolyStart = iPolyEnd + 1;
-                            iPolyEnd = pscSectionProperty.IndexOf("IPOLY", iPolyStart + 1);
+                            iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY"));
                         }
 
                         // For the final IPoly
@@ -177,7 +178,6 @@ namespace BH.Adapter.MidasCivil
 
                     //Set i index for next section property
                     i = iEnd;
-
                 }
             }
 

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -195,6 +195,11 @@ namespace BH.Adapter.MidasCivil
                     //Set i index for next section property
                     i = iEnd;
                 }
+                else if(type == "COMPOSITE-GEN")
+                {
+                    Engine.Base.Compute.RecordWarning("MidasCivil_Toolkit does not support COMPOSITE-GEN sections, this section has been skipped.");
+                    i = iEnd;
+                }
             }
 
 

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -168,6 +168,14 @@ namespace BH.Adapter.MidasCivil
                             else
                                 iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY")) - 1;
                         }
+
+                        // For the final inner polyline contained on a single line
+                        if (iPolyStart == pscSectionProperty.Count -1 && iPolyEnd == -2)
+                        {
+                            iPolyEnd = pscSectionProperty.Count - 1;
+                            polys.Add(new Polyline() { ControlPoints = ParsePoints(pscSectionProperty, iPolyStart, iPolyEnd, "IPOLY") });
+                        }    
+
                     }
 
                     List<string> split = sectionProfile.Split(',').ToList();

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -147,26 +147,27 @@ namespace BH.Adapter.MidasCivil
                     {
                         // Inner polylines always follow outer, find the start of the next IPOLY otherwise it's the end of the PSC Section
                         int iPolyStart = iOPolyEnd + 1;
-                        int iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY")) - 1;
+                        int iPolyEnd = -2;
+                        if(!(iPolyStart + 1 > pscSectionProperty.Count - 1))
+                            iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY")) - 1;
 
+                        // This is the case where IPOLY is contained on a single line (i.e. three points)
                         if (iPolyEnd == -2)
                             iPolyEnd = pscSectionProperty.Count - 1;
 
-                        // Iterate through each IPoly 
+                        // Iterate through each IPoly, index of -2 identifies no more IPOLY
                         while (!(iPolyEnd == -2))
                         {
                             polys.Add(new Polyline() { ControlPoints = ParsePoints(pscSectionProperty, iPolyStart, iPolyEnd, "IPOLY") });
 
-                            // Get indexes for next polyline
+                            // Get indexes for next polyline, IF statement to avoid out of index if there is a single IPOLY
                             iPolyStart = iPolyEnd + 1;
-                            iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY")) - 1;
+                            //This is the last IPOLY
+                            if(iPolyStart > pscSectionProperty.Count() -1)
+                                iPolyEnd = -2;
+                            else
+                                iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY")) - 1;
                         }
-
-                        // For the final inner polyline
-                        if (iPolyEnd == -2)
-                            iPolyEnd = pscSectionProperty.Count - 1;
-
-                        polys.Add(new Polyline() { ControlPoints = ParsePoints(pscSectionProperty, iPolyStart, iPolyEnd, "IPOLY") });
                     }
 
                     List<string> split = sectionProfile.Split(',').ToList();

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -190,7 +190,7 @@ namespace BH.Adapter.MidasCivil
 
 
 
-                return bhomSectionProperties;
+            return bhomSectionProperties;
         }
 
         /***************************************************/
@@ -198,7 +198,7 @@ namespace BH.Adapter.MidasCivil
         private List<Point> ParsePoints(List<string> text, int start, int end, string excluder)
         {
             List<Point> parsedPoints = new List<Point>();
-            
+
             //Generate polyline by extracting points from each line (variable number of points per line)
             for (int i = start; i < end + 1; i++)
             {
@@ -210,7 +210,7 @@ namespace BH.Adapter.MidasCivil
                 string[] polyCoords = polyText.Split(',');
 
                 // Each point is formatted X, Y in pairs with each line containing up to four points
-                for (int j = 0; j < polyCoords.Count() - 1; j+=2)
+                for (int j = 0; j < polyCoords.Count() - 1; j += 2)
                     parsedPoints.Add(new Point() { X = double.Parse(polyCoords[j].Trim()), Y = double.Parse(polyCoords[j + 1].Trim()) });
 
             }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
@@ -33,7 +33,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static IProfile ToProfile(List<string> sectionProfile, string shape, string lengthUnit)
+        public static IProfile ToProfile(List<string> sectionProfile, string shape, string lengthUnit, List<Polyline> edges = null)
         {
             IProfile bhomProfile = null;
             double width;
@@ -130,6 +130,9 @@ namespace BH.Adapter.Adapters.MidasCivil
                             System.Convert.ToDouble(sectionProfile[0]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[1]).LengthToSI(lengthUnit),
                             System.Convert.ToDouble(sectionProfile[2]).LengthToSI(lengthUnit), System.Convert.ToDouble(sectionProfile[3]).LengthToSI(lengthUnit),
                             0, 0, false, true);
+                    break;
+                case "GEN":
+                    bhomProfile = Engine.Spatial.Create.FreeFormProfile(edges);
                     break;
             }
 

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
@@ -109,12 +109,12 @@ namespace BH.Adapter.Adapters.MidasCivil
                     topFlangeThickness = System.Convert.ToDouble(sectionProfile[3]);
                     bottomFlangeThickness = System.Convert.ToDouble(sectionProfile[5]);
 
-                    if(Math.Abs(topFlangeWidth - bottomFlangeWidth) > Tolerance.Distance && bottomFlangeWidth > Tolerance.Distance)
+                    if (Math.Abs(topFlangeWidth - bottomFlangeWidth) > Tolerance.Distance && bottomFlangeWidth > Tolerance.Distance)
                     {
                         Engine.Base.Compute.RecordWarning("Asymmetric channel sections are not yet supported by the BHoM. The top flange width will be used for the profile.");
                     }
-                    
-                    if(Math.Abs(topFlangeThickness - bottomFlangeThickness) > Tolerance.Distance && bottomFlangeThickness > Tolerance.Distance)
+
+                    if (Math.Abs(topFlangeThickness - bottomFlangeThickness) > Tolerance.Distance && bottomFlangeThickness > Tolerance.Distance)
                     {
                         Engine.Base.Compute.RecordWarning("Asymmetric channel sections are not yet supported by the BHoM. The top flange thickness will be used for the profile.");
                     }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSectionProperty.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Geometry;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Spatial.ShapeProfiles;
@@ -45,9 +46,9 @@ namespace BH.Adapter.Adapters.MidasCivil
         /***************************************************/
 
         public static ISectionProperty ToSectionProperty(this List<string> sectionProfile, string sectionProperty1,
-            string sectionProperty2, string sectionProperty3, string shape, string lengthUnit)
+            string sectionProperty2, string sectionProperty3, string shape, string lengthUnit, List<Polyline> edges = null)
         {
-            IProfile bhomProfile = ToProfile(sectionProfile, shape, lengthUnit);
+            IProfile bhomProfile = ToProfile(sectionProfile, shape, lengthUnit, edges);
 
             string[] split1 = sectionProperty1.Split(',');
             string[] split2 = sectionProperty2.Split(',');
@@ -58,8 +59,13 @@ namespace BH.Adapter.Adapters.MidasCivil
             double iz = System.Convert.ToDouble(split1[5]).AreaMomentOfInertiaToSI(lengthUnit);
             double iy = System.Convert.ToDouble(split1[4]).AreaMomentOfInertiaToSI(lengthUnit);
             double iw = bhomProfile.IWarpingConstant().AreaMomentOfInertiaToSI(lengthUnit);
-            double wply = System.Convert.ToDouble(split3[8]).VolumeToSI(lengthUnit);
-            double wplz = System.Convert.ToDouble(split3[9]).VolumeToSI(lengthUnit);
+            double wply = 0;
+            double wplz = 0;
+            if(!(shape == "GEN"))
+            {
+                wply = System.Convert.ToDouble(split3[8]).VolumeToSI(lengthUnit);
+                wplz = System.Convert.ToDouble(split3[9]).VolumeToSI(lengthUnit);
+            }
             double centreZ = System.Convert.ToDouble(split2[9]).LengthToSI(lengthUnit);
             double centreY = -System.Convert.ToDouble(split2[8]).LengthToSI(lengthUnit);
             double zt = System.Convert.ToDouble(split2[2]).LengthToSI(lengthUnit);

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -127,39 +127,6 @@ namespace BH.Adapter.Adapters.MidasCivil
                     Engine.Base.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
                     return null;
                 }
-                else if (sectionProperty.SectionProfile is FreeFormProfile)
-                {
-                    FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
-
-                    // Add the preamble required for the section property
-                    midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
-                            new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                            ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
-                    // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
-                    midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
-                        sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
-
-                    List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
-                    double outerPerimeter = perimeters[0].ILength();
-                    double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
-
-                    // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
-                    midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                        + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
-                        sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
-
-                    //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                    List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
-
-                    Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-
-                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
-                }
                 else
                 {
                     midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
@@ -168,6 +135,39 @@ namespace BH.Adapter.Adapters.MidasCivil
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
                     midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
                 }
+            }
+            else if (sectionProperty.SectionProfile is FreeFormProfile)
+            {
+                FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
+
+                // Add the preamble required for the section property
+                midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
+                // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
+                midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
+                    sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
+
+                List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
+                double outerPerimeter = perimeters[0].ILength();
+                double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
+
+                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
+
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
+                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+
+                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
             }
             else
             {
@@ -193,39 +193,6 @@ namespace BH.Adapter.Adapters.MidasCivil
                     Engine.Base.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
                     return null;
                 }
-                else if (sectionProperty.SectionProfile is FreeFormProfile)
-                {
-                    FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
-
-                    // Add the preamble required for the section property
-                    midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
-                            new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                            ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
-                    // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
-                    midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
-                        sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
-
-                    List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
-                    double outerPerimeter = perimeters[0].ILength();
-                    double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
-
-                    // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
-                    midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                        + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
-                        sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
-
-                    //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                    List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
-
-                    Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-
-                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
-                }
                 else
                 {
                     midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
@@ -234,6 +201,39 @@ namespace BH.Adapter.Adapters.MidasCivil
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
                     midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
                 }
+            }
+            else if (sectionProperty.SectionProfile is FreeFormProfile)
+            {
+                FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
+
+                // Add the preamble required for the section property
+                midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
+                // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
+                midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
+                    sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
+
+                List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
+                double outerPerimeter = perimeters[0].ILength();
+                double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
+
+                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
+
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
+                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+
+                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
             }
             else
             {
@@ -259,39 +259,6 @@ namespace BH.Adapter.Adapters.MidasCivil
                     Engine.Base.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
                     return null;
                 }
-                else if (sectionProperty.SectionProfile is FreeFormProfile)
-                {
-                    FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
-
-                    // Add the preamble required for the section property
-                    midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
-                            new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                            ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
-                    // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
-                    midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
-                        sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
-
-                    List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
-                    double outerPerimeter = perimeters[0].ILength();
-                    double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
-
-                    // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
-                    midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                        + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
-                        sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
-
-                    //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                    List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
-
-                    Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-
-                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
-                }
                 else
                 {
                     midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
@@ -300,6 +267,39 @@ namespace BH.Adapter.Adapters.MidasCivil
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
                     midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
                 }
+            }
+            else if (sectionProperty.SectionProfile is FreeFormProfile)
+            {
+                FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
+
+                // Add the preamble required for the section property
+                midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
+                // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
+                midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
+                    sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
+
+                List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
+                double outerPerimeter = perimeters[0].ILength();
+                double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
+
+                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
+
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
+                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+
+                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
             }
             else
             {
@@ -325,39 +325,6 @@ namespace BH.Adapter.Adapters.MidasCivil
                     Engine.Base.Compute.RecordError("MidasCivil_Toolkit does not support TaperedProfiles with different section shapes.");
                     return null;
                 }
-                else if (sectionProperty.SectionProfile is FreeFormProfile)
-                {
-                    FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
-
-                    // Add the preamble required for the section property
-                    midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
-                            new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                            ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
-                    // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
-                    midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
-                        sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
-
-                    List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
-                    double outerPerimeter = perimeters[0].ILength();
-                    double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
-
-                    // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
-                    midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                        + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
-                        sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
-
-                    //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                    List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
-
-                    Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-
-                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
-                }
                 else
                 {
                     midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
@@ -366,6 +333,39 @@ namespace BH.Adapter.Adapters.MidasCivil
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
                     midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
                 }
+            }
+            else if (sectionProperty.SectionProfile is FreeFormProfile)
+            {
+                FreeFormProfile freeformProfile = (FreeFormProfile)sectionProperty.SectionProfile;
+
+                // Add the preamble required for the section property
+                midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
+                        new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
+                        ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
+                // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
+                midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
+                    sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
+
+                List<ICurve> perimeters = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
+                double outerPerimeter = perimeters[0].ILength();
+                double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
+
+                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
+
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
+                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+
+                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
             }
             else
             {
@@ -527,17 +527,6 @@ namespace BH.Adapter.Adapters.MidasCivil
         private static string CreateProfile(ZSectionProfile profile, string lengthUnit)
         {
             Engine.Base.Compute.RecordError("ZSectionProfile not supported by the MidasCivil_Toolkit");
-
-            return null;
-        }
-
-        /***************************************************/
-
-        private static string CreateProfile(FreeFormProfile profile, string lengthUnit)
-        {
-
-
-            Engine.Base.Compute.RecordError("FreeFormProfile not supported by the MidasCivil_Toolkit");
 
             return null;
         }

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -226,9 +226,20 @@ namespace BH.Adapter.Adapters.MidasCivil
                 double outerPerimeter = perimeters[0].ILength();
                 double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
 
-                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                //Calculate total width of section
+                BoundingBox outerBounds = perimeters[0].IBounds();
+                double totalWidth = outerBounds.Max.X - outerBounds.Min.X;
+                double totalDepth = outerBounds.Max.Y - outerBounds.Min.Y;
+
+                // Calculate the width of the openings and subtract from the width of the section
+                for (int i = 1; i < perimeters.Count; i++)
+                {
+                    totalWidth = totalWidth - (perimeters[i].IBounds().Max.X - perimeters[i].IBounds().Min.X);
+                    totalDepth = totalDepth - (perimeters[i].IBounds().Max.Y - perimeters[i].IBounds().Min.Y);
+                }
+
                 midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
@@ -352,9 +363,20 @@ namespace BH.Adapter.Adapters.MidasCivil
                 double outerPerimeter = perimeters[0].ILength();
                 double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
 
-                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                //Calculate total width of section
+                BoundingBox outerBounds = perimeters[0].IBounds();
+                double totalWidth = outerBounds.Max.X - outerBounds.Min.X;
+                double totalDepth = outerBounds.Max.Y - outerBounds.Min.Y;
+
+                // Calculate the width of the openings and subtract from the width of the section
+                for (int i = 1; i < perimeters.Count; i++)
+                {
+                    totalWidth = totalWidth - (perimeters[i].IBounds().Max.X - perimeters[i].IBounds().Min.X);
+                    totalDepth = totalDepth - (perimeters[i].IBounds().Max.Y - perimeters[i].IBounds().Min.Y);
+                }
+
                 midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
@@ -478,9 +500,20 @@ namespace BH.Adapter.Adapters.MidasCivil
                 double outerPerimeter = perimeters[0].ILength();
                 double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
 
-                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                //Calculate total width of section
+                BoundingBox outerBounds = perimeters[0].IBounds();
+                double totalWidth = outerBounds.Max.X - outerBounds.Min.X;
+                double totalDepth = outerBounds.Max.Y - outerBounds.Min.Y;
+
+                // Calculate the width of the openings and subtract from the width of the section
+                for (int i = 1; i < perimeters.Count; i++)
+                {
+                    totalWidth = totalWidth - (perimeters[i].IBounds().Max.X - perimeters[i].IBounds().Min.X);
+                    totalDepth = totalDepth - (perimeters[i].IBounds().Max.Y - perimeters[i].IBounds().Min.Y);
+                }
+
                 midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
@@ -604,9 +637,20 @@ namespace BH.Adapter.Adapters.MidasCivil
                 double outerPerimeter = perimeters[0].ILength();
                 double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
 
-                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                //Calculate total width of section
+                BoundingBox outerBounds = perimeters[0].IBounds();
+                double totalWidth = outerBounds.Max.X - outerBounds.Min.X;
+                double totalDepth = outerBounds.Max.Y - outerBounds.Min.Y;
+
+                // Calculate the width of the openings and subtract from the width of the section
+                for (int i = 1; i < perimeters.Count; i++)
+                {
+                    totalWidth = totalWidth - (perimeters[i].IBounds().Max.X - perimeters[i].IBounds().Min.X);
+                    totalDepth = totalDepth - (perimeters[i].IBounds().Max.Y - perimeters[i].IBounds().Min.Y);
+                }
+
                 midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -103,8 +103,9 @@ namespace BH.Adapter.Adapters.MidasCivil
                 if (controlPoints.Count == 4)
                 {
                     p1 = controlPoints[0];
-                    p2 = controlPoints[1];
-                    p3 = controlPoints[2];
+                    p2 = controlPoints[0];
+                    p3 = controlPoints[1];
+                    p4 = controlPoints[2];
 
                     midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}," +
                         $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}");

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -91,17 +91,36 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
+                ICurve oPoly = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
+                List<Point> controlPoints = oPoly.IControlPoints();
 
-                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p1 = null;
+                Point p2 = null;
+                Point p3 = null;
+                Point p4 = null;
 
-                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                if (controlPoints.Count == 4)
+                {
+                    p1 = controlPoints[0];
+                    p2 = controlPoints[1];
+                    p3 = controlPoints[2];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
+                else
+                {
+                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
             }
             else
             {
@@ -157,17 +176,36 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
+                ICurve oPoly = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
+                List<Point> controlPoints = oPoly.IControlPoints();
 
-                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p1 = null;
+                Point p2 = null;
+                Point p3 = null;
+                Point p4 = null;
 
-                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                if (controlPoints.Count == 4)
+                {
+                    p1 = controlPoints[0];
+                    p2 = controlPoints[1];
+                    p3 = controlPoints[2];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
+                else
+                {
+                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
             }
             else
             {
@@ -223,17 +261,36 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
+                ICurve oPoly = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
+                List<Point> controlPoints = oPoly.IControlPoints();
 
-                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p1 = null;
+                Point p2 = null;
+                Point p3 = null;
+                Point p4 = null;
 
-                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                if (controlPoints.Count == 4)
+                {
+                    p1 = controlPoints[0];
+                    p2 = controlPoints[1];
+                    p3 = controlPoints[2];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
+                else
+                {
+                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
             }
             else
             {
@@ -289,17 +346,36 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
+                ICurve oPoly = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
+                List<Point> controlPoints = oPoly.IControlPoints();
 
-                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p1 = null;
+                Point p2 = null;
+                Point p3 = null;
+                Point p4 = null;
 
-                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                if (controlPoints.Count == 4)
+                {
+                    p1 = controlPoints[0];
+                    p2 = controlPoints[1];
+                    p3 = controlPoints[2];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
+                else
+                {
+                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
             }
             else
             {
@@ -355,17 +431,36 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
-                List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
+                //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
+                ICurve oPoly = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
+                List<Point> controlPoints = oPoly.IControlPoints();
 
-                Point p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                Point p1 = null;
+                Point p2 = null;
+                Point p3 = null;
+                Point p4 = null;
 
-                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
-                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
-                midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                if (controlPoints.Count == 4)
+                {
+                    p1 = controlPoints[0];
+                    p2 = controlPoints[1];
+                    p3 = controlPoints[2];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
+                else
+                {
+                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+
+                    midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                        $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                    midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
+                }
             }
             else
             {
@@ -752,14 +847,14 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             List<ICurve> edges = sectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
 
-            List<Point> oPolyPoints = edges[0].IControlPoints();
+            List<Point> oPolyPoints = Engine.Geometry.Compute.ISortAlongCurve(edges[0].IControlPoints(),edges[0]).Distinct().ToList();
 
             profile.AddRange(CreatePolystring(oPolyPoints, "OPOLY", lengthUnit));
 
             if (edges.Count > 1)
             {
-                for (int i = 1; i < edges.Count - 1; i++)
-                    profile.AddRange(CreatePolystring(edges[i].IControlPoints(), "IPOLY", lengthUnit));
+                for (int i = 1; i < edges.Count; i++)
+                    profile.AddRange(CreatePolystring(Engine.Geometry.Compute.ISortAlongCurve(edges[i].IControlPoints(),edges[i]).Distinct().ToList(), "IPOLY", lengthUnit));
             }
             return profile;
         }
@@ -775,21 +870,21 @@ namespace BH.Adapter.Adapters.MidasCivil
             poly.Add($"{polytype}={polyPoints[0].X.LengthFromSI(lengthUnit)},{polyPoints[0].Y.LengthFromSI(lengthUnit)},{polyPoints[1].X.LengthFromSI(lengthUnit)},{polyPoints[1].Y.LengthFromSI(lengthUnit)}," +
                 $"{polyPoints[2].X.LengthFromSI(lengthUnit)},{polyPoints[2].Y.LengthFromSI(lengthUnit)}");
 
-            if (polyCount > 4)
+            if (polyCount > 3)
             {
-                for (int i = 3; i < polyCount - 4; i += 4)
+                for (int i = 3; i < polyCount - 3; i += 4)
                 {
                     poly.Add($"{polyPoints[i].X.LengthFromSI(lengthUnit)},{polyPoints[i].Y.LengthFromSI(lengthUnit)},{polyPoints[i + 1].X.LengthFromSI(lengthUnit)},{polyPoints[i + 1].Y.LengthFromSI(lengthUnit)}," +
                         $"{polyPoints[i + 2].X.LengthFromSI(lengthUnit)},{polyPoints[i + 2].Y.LengthFromSI(lengthUnit)},{polyPoints[i + 3].X.LengthFromSI(lengthUnit)},{polyPoints[i + 3].Y.LengthFromSI(lengthUnit)}");
                 }
 
-                // 4 because 3 initial points and last point we do not want (as it is a duplicate)
-                int remainderPointsCount = (polyCount - 4) % 4;
+                // 3 because 3 initial points (no duplicate points as Dinstict() used in input for this method)
+                int remainderPointsCount = (polyCount - 3) % 4;
 
                 if (remainderPointsCount > 0)
                 {
                     string remainderPoints = "";
-                    for (int j = polyCount - 2; j > polyCount - remainderPointsCount - 2; j--)
+                    for (int j = polyCount - remainderPointsCount; j < polyCount; j++)
                     {
                         if (remainderPoints == "")
                             remainderPoints = polyPoints[j].X.LengthFromSI(lengthUnit) + "," + polyPoints[j].Y.LengthFromSI(lengthUnit);

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -99,8 +99,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                 Point p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
                 Point p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
 
-                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p1.Y.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p2.Y.LengthFromSI(lengthUnit)}, " +
-                    $"{p3.X.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
+                midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
+                    $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
                 midasSectionProperty.AddRange(CreatePSCProfile(freeformProfile, lengthUnit));
             }
             else
@@ -675,6 +675,9 @@ namespace BH.Adapter.Adapters.MidasCivil
                         else
                             remainderPoints = remainderPoints + "," + polyPoints[j].X + "," + polyPoints[j].Y;
                     }
+
+                    poly.Add(remainderPoints);
+
                 }
             }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -113,10 +113,50 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    // In general there will be a point in each quadrant, but there are instances where they are not 
+                    List<Point> q1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+
+                    List<Point> p1p2p3p4 = new List<Point>();
+
+                    // Take the first point from each list - this works for a point in each quadrant and for the scenario where three points exist in a single quadrant 
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int j = 0;
+                        while (j < 4)
+                        {
+                            if (q1.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q1[i]);
+                                j = j + 1;
+                            }
+                            if (q2.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q2[i]);
+                                j = j + 1;
+                            }
+                            if (q3.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q3[i]);
+                                j = j + 1;
+                            }
+                            if (q4.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q4[i]);
+                                j = j + 1;
+                            }
+                        }
+
+                        if (j == 4)
+                            break;
+                    }
+
+                    p1 = p1p2p3p4[0];
+                    p2 = p1p2p3p4[1];
+                    p3 = p1p2p3p4[2];
+                    p4 = p1p2p3p4[3];
 
                     midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
                         $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
@@ -199,10 +239,50 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    // In general there will be a point in each quadrant, but there are instances where they are not 
+                    List<Point> q1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+
+                    List<Point> p1p2p3p4 = new List<Point>();
+
+                    // Take the first point from each list - this works for a point in each quadrant and for the scenario where three points exist in a single quadrant 
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int j = 0;
+                        while (j < 4)
+                        {
+                            if (q1.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q1[i]);
+                                j = j + 1;
+                            }
+                            if (q2.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q2[i]);
+                                j = j + 1;
+                            }
+                            if (q3.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q3[i]);
+                                j = j + 1;
+                            }
+                            if (q4.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q4[i]);
+                                j = j + 1;
+                            }
+                        }
+
+                        if (j == 4)
+                            break;
+                    }
+
+                    p1 = p1p2p3p4[0];
+                    p2 = p1p2p3p4[1];
+                    p3 = p1p2p3p4[2];
+                    p4 = p1p2p3p4[3];
 
                     midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
                         $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
@@ -285,10 +365,50 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    // In general there will be a point in each quadrant, but there are instances where they are not 
+                    List<Point> q1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+
+                    List<Point> p1p2p3p4 = new List<Point>();
+
+                    // Take the first point from each list - this works for a point in each quadrant and for the scenario where three points exist in a single quadrant 
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int j = 0;
+                        while (j < 4)
+                        {
+                            if (q1.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q1[i]);
+                                j = j + 1;
+                            }
+                            if (q2.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q2[i]);
+                                j = j + 1;
+                            }
+                            if (q3.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q3[i]);
+                                j = j + 1;
+                            }
+                            if (q4.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q4[i]);
+                                j = j + 1;
+                            }
+                        }
+
+                        if (j == 4)
+                            break;
+                    }
+
+                    p1 = p1p2p3p4[0];
+                    p2 = p1p2p3p4[1];
+                    p3 = p1p2p3p4[2];
+                    p4 = p1p2p3p4[3];
 
                     midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
                         $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
@@ -371,10 +491,50 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    // In general there will be a point in each quadrant, but there are instances where they are not 
+                    List<Point> q1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+
+                    List<Point> p1p2p3p4 = new List<Point>();
+
+                    // Take the first point from each list - this works for a point in each quadrant and for the scenario where three points exist in a single quadrant 
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int j = 0;
+                        while (j < 4)
+                        {
+                            if (q1.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q1[i]);
+                                j = j + 1;
+                            }
+                            if (q2.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q2[i]);
+                                j = j + 1;
+                            }
+                            if (q3.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q3[i]);
+                                j = j + 1;
+                            }
+                            if (q4.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q4[i]);
+                                j = j + 1;
+                            }
+                        }
+
+                        if (j == 4)
+                            break;
+                    }
+
+                    p1 = p1p2p3p4[0];
+                    p2 = p1p2p3p4[1];
+                    p3 = p1p2p3p4[2];
+                    p4 = p1p2p3p4[3];
 
                     midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
                         $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");
@@ -446,6 +606,7 @@ namespace BH.Adapter.Adapters.MidasCivil
 
                 if (controlPoints.Count == 4)
                 {
+                    // For a triangle, a single point need to be repeated
                     p1 = controlPoints[0];
                     p2 = controlPoints[0];
                     p3 = controlPoints[1];
@@ -457,10 +618,50 @@ namespace BH.Adapter.Adapters.MidasCivil
                 }
                 else
                 {
-                    p1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
-                    p4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList()[0];
+                    // In general there will be a point in each quadrant, but there are instances where they are not 
+                    List<Point> q1 = controlPoints.Where(x => x.Y > 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q2 = controlPoints.Where(x => x.Y > 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q3 = controlPoints.Where(x => x.Y < 0).Where(x => x.X < 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+                    List<Point> q4 = controlPoints.Where(x => x.Y < 0).Where(x => x.X > 0).OrderBy(x => x.Distance(new Point())).Reverse().ToList();
+
+                    List<Point> p1p2p3p4 = new List<Point>();
+
+                    // Take the first point from each list - this works for a point in each quadrant and for the scenario where three points exist in a single quadrant 
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int j = 0;
+                        while (j < 4)
+                        {
+                            if (q1.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q1[i]);
+                                j = j + 1;
+                            }
+                            if (q2.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q2[i]);
+                                j = j + 1;
+                            }
+                            if (q3.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q3[i]);
+                                j = j + 1;
+                            }
+                            if (q4.ElementAtOrDefault(i) != null)
+                            {
+                                p1p2p3p4.Add(q4[i]);
+                                j = j + 1;
+                            }
+                        }
+
+                        if (j == 4)
+                            break;
+                    }
+
+                    p1 = p1p2p3p4[0];
+                    p2 = p1p2p3p4[1];
+                    p3 = p1p2p3p4[2];
+                    p4 = p1p2p3p4[3];
 
                     midasSectionProperty.Add($"{p1.X.LengthFromSI(lengthUnit)}, {p2.X.LengthFromSI(lengthUnit)}, {p3.X.LengthFromSI(lengthUnit)}, {p4.X.LengthFromSI(lengthUnit)}," +
                         $"{p1.Y.LengthFromSI(lengthUnit)},{p2.Y.LengthFromSI(lengthUnit)}, {p3.Y.LengthFromSI(lengthUnit)}, {p4.Y.LengthFromSI(lengthUnit)}");

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -93,8 +93,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                Engine.Base.Compute.RecordError("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
-                Engine.Base.Compute.RecordError("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
+                Engine.Base.Compute.RecordWarning("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
+                Engine.Base.Compute.RecordWarning("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
                 ICurve oPoly = freeformProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
@@ -162,8 +162,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                Engine.Base.Compute.RecordError("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
-                Engine.Base.Compute.RecordError("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
+                Engine.Base.Compute.RecordWarning("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
+                Engine.Base.Compute.RecordWarning("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
                 ICurve oPoly = freeformProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
@@ -231,8 +231,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                Engine.Base.Compute.RecordError("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
-                Engine.Base.Compute.RecordError("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
+                Engine.Base.Compute.RecordWarning("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
+                Engine.Base.Compute.RecordWarning("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
                 ICurve oPoly = freeformProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
@@ -300,8 +300,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                Engine.Base.Compute.RecordError("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
-                Engine.Base.Compute.RecordError("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
+                Engine.Base.Compute.RecordWarning("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
+                Engine.Base.Compute.RecordWarning("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
                 ICurve oPoly = freeformProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];
@@ -369,8 +369,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) / totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) / totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
-                Engine.Base.Compute.RecordError("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
-                Engine.Base.Compute.RecordError("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
+                Engine.Base.Compute.RecordWarning("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
+                Engine.Base.Compute.RecordWarning("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
                 ICurve oPoly = freeformProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -89,7 +89,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
                 midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
                     + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
-                    sectionProperty.Vpy.LengthFromSI(lengthUnit) + sectionProperty.Vpz.LengthFromSI(lengthUnit));
+                    sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left)
                 List<Point> controlPoints = sectionProperty.SectionProfile.Edges.Select(x => x.IControlPoints()).SelectMany(x => x).ToList();
@@ -629,7 +629,7 @@ namespace BH.Adapter.Adapters.MidasCivil
         {
             List<string> profile = new List<string>();
 
-            List<ICurve> edges = sectionProfile.Edges.OrderBy(x => x.ILength()).ToList();
+            List<ICurve> edges = sectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList();
 
             List<Point> oPolyPoints = edges[0].IControlPoints();
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -86,10 +86,24 @@ namespace BH.Adapter.Adapters.MidasCivil
                 double outerPerimeter = perimeters[0].ILength();
                 double innerPerimeter = perimeters.Sum(x => x.ILength()) - outerPerimeter;
 
-                // 5th and 6th number is the shear factor for shear stress (Qyb, Qzb) - contacting Midas how to resolve
+                //Calculate total width of section
+                BoundingBox outerBounds = perimeters[0].IBounds();
+                double totalWidth = outerBounds.Max.X - outerBounds.Min.X;
+                double totalDepth = outerBounds.Max.Y - outerBounds.Min.Y;
+
+                // Calculate the width of the openings and subtract from the width of the section
+                for (int i = 1; i < perimeters.Count; i++)
+                {
+                    totalWidth = totalWidth - (perimeters[i].IBounds().Max.X - perimeters[i].IBounds().Min.X);
+                    totalDepth = totalDepth - (perimeters[i].IBounds().Max.Y - perimeters[i].IBounds().Min.Y);
+                }
+
                 midasSectionProperty.Add(sectionProperty.Vy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vz.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit)
-                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit) + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit) + "," + outerPerimeter + "," + innerPerimeter + "," +
+                    + "," + sectionProperty.Wely.VolumeFromSI(lengthUnit)/totalWidth + "," + sectionProperty.Welz.VolumeFromSI(lengthUnit)/totalDepth + "," + outerPerimeter + "," + innerPerimeter + "," +
                     sectionProperty.Vpy.LengthFromSI(lengthUnit) + "," + sectionProperty.Vpz.LengthFromSI(lengthUnit));
+
+                Engine.Base.Compute.RecordError("The shear factor (Qby and Qbz) are calculated by determining the thickness of the voided section and can differ from the Midas SPC calcualted values.");
+                Engine.Base.Compute.RecordError("The shear areas are calculated using integration and can differ from the Midas SPC calculated value.");
 
                 //Work out extreme points in each corner of the section p1 (top left), p2 (top right), p3 (bottom right), p4 (bottom left) of the outer polyline
                 ICurve oPoly = sectionProperty.SectionProfile.Edges.OrderBy(x => x.ILength()).Reverse().ToList()[0];

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -78,7 +78,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 midasSectionProperty.Add("SECT=" + sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," +
                         new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
                         ",CC, 0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + ",YES,YES");
-                // Add the values corresponding to the section properties
+                // Add the values corresponding to the section properties, Asy and Asz are currently quite different between MidasCivil and BHoM (ticket raised)
                 midasSectionProperty.Add(sectionProperty.Area.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asy.AreaFromSI(lengthUnit).ToString() + "," + sectionProperty.Asz.AreaFromSI(lengthUnit).ToString() + "," +
                     sectionProperty.J.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iy.AreaMomentOfInertiaFromSI(lengthUnit).ToString() + "," + sectionProperty.Iz.AreaMomentOfInertiaFromSI(lengthUnit).ToString());
 

--- a/MidasCivil_Adapter/PrivateHelpers/GetAssignmentIds.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/GetAssignmentIds.cs
@@ -46,6 +46,10 @@ namespace BH.Adapter.MidasCivil
                 {
                     propertyAssignment.AddRange(RangeBySplit(assignment, "to"));
                 }
+                else if(assignment == "")
+                {
+                    continue;
+                }
                 else
                 {
                     int id = System.Convert.ToInt32(assignment);

--- a/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
@@ -108,18 +108,14 @@ namespace BH.Adapter.MidasCivil
 
         private static string SectionName(string text)
         {
-            if (text.Contains(","))
-            {
+            if (text.Contains("USE-STLD"))
                 return text.Split(',')[0].Split('*')[1];
-            }
+            else if (text.Contains(";"))
+                return text.Split(';')[0].Split('*')[1].Trim();
             else if (text.Contains(" "))
-            {
                 return text.Split(' ')[0].Split('*')[1];
-            }
             else
-            {
                 return text.Split('*')[1];
-            }
         }
 
         /***************************************************/

--- a/MidasCivil_Adapter/Type/NextFreeId.cs
+++ b/MidasCivil_Adapter/Type/NextFreeId.cs
@@ -129,10 +129,24 @@ namespace BH.Adapter.MidasCivil
                 if (typeof(ISectionProperty).IsAssignableFrom(type))
                 {
                     string section = "SECTION";
+                    string pscSection = "SECT-PSCVALUE";
 
-                    if (ExistsSection(section))
+                    int sectionIndex = 0;
+                    int pscSectionIndex = 0;
+
+                    if (ExistsSection(section) && ExistsSection(pscSection))
                     {
-                        index = GetMaxId(section) + 1;
+                        sectionIndex = Math.Max(GetMaxId(section), GetMaxId(pscSection));
+                    }
+                    else if (ExistsSection(section))
+                    {
+                        pscSectionIndex = GetMaxId(section);
+
+                    }
+                    else if (ExistsSection(pscSection))
+                    {
+                        pscSectionIndex = GetMaxId(pscSection);
+
                     }
                     else
                     {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #332 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Push and pull](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23332%20Add%20Freeform%20Profiles?csf=1&web=1&e=TOnDcs)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Added support for pushing `FreeformProfile` 
Added support for pulling PSC-Value General sections

### Additional comments
<!-- As required -->
~The Shear Factor for Shear Stress (Qby, Qbz) is not clear how to calculate it for PSC-Value sections - I have contacted Midas regarding this.~ Added calculation.
~The Asy and Asz is also different to what our integration method is calculation - so will need some testing.~ Will leave it based on integration methods.
~There is also a visual bug for plates at 40mm.~ Purely visual.

Tickets raised here:
https://globalsupport.midasuser.com/helpdesk/Ticket/61518403
https://globalsupport.midasuser.com/helpdesk/Ticket/61637483