### PR TITLE
Add statement to identify start of section inputs to simplify statements for skipping unsupported sections

### DIFF
--- a/MidasCivil_Adapter/CRUD/Read/Properties/Materials.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/Materials.cs
@@ -40,7 +40,8 @@ namespace BH.Adapter.MidasCivil
             foreach (string material in materialText)
             {
                 IMaterialFragment bhomMaterial = Adapters.MidasCivil.Convert.ToMaterial(material, m_forceUnit, m_lengthUnit, m_temperatureUnit);
-                bhomMaterials.Add(bhomMaterial);
+                if (bhomMaterial != null)
+                    bhomMaterials.Add(bhomMaterial);
             }
 
             return bhomMaterials;

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -61,7 +61,10 @@ namespace BH.Adapter.MidasCivil
             foreach (int index in indexes)
             {
                 string sectionProperty = sectionProperties[index];
-                string type = sectionProperty.Split(',')[1].Trim();
+                List<string> split = sectionProperty.Split(',').ToList();
+
+                string type = split[1].Trim();
+
 
                 ISectionProperty bhomSectionProperty = null;
 
@@ -71,8 +74,6 @@ namespace BH.Adapter.MidasCivil
                     string sectionProperties1 = sectionProperties[index + 1];
                     string sectionProperties2 = sectionProperties[index + 2];
                     string sectionProperties3 = sectionProperties[index + 3];
-
-                    List<string> split = sectionProfile.Split(',').ToList();
 
                     bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(
                         split.GetRange(14, sectionProperty.Split(',').Count() - 15), sectionProperties1, sectionProperties2, sectionProperties3,
@@ -87,11 +88,18 @@ namespace BH.Adapter.MidasCivil
 
                     if (numberColumns == 16)
                     {
-                        Engine.Base.Compute.RecordWarning("Library sections are not yet supported in the MidasCivil_Toolkit");
+                        // delimitted[15] is the database name of the section
+                        bhomSectionProperty = (ISectionProperty)Engine.Library.Query.Match("Structure\\SectionProperties",split[15]);
+                        if (bhomSectionProperty == null)
+                            Engine.Base.Compute.RecordWarning("The database section " + split[2] + " could not be found in the BHoM datasets - a null value has been assigned.");
+                        else
+                        {
+                            bhomSectionProperty.SetAdapterId(typeof(MidasCivilId), split[0].Trim());
+                            Engine.Base.Compute.RecordWarning("The section " + split[2] + " has been assigned from BHoMDatasets, note the material is the same as the database section.");
+                        }
                     }
                     else
                     {
-                        List<string> split = sectionProperty.Split(',').ToList();
                         bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(split.GetRange(14, numberColumns - 16),
                             split[12].Trim(), m_lengthUnit);
 
@@ -101,7 +109,6 @@ namespace BH.Adapter.MidasCivil
                 }
                 else if (type == "TAPERED")
                 {
-                    List<string> split = sectionProperty.Split(',').ToList();
                     List<string> profiles = sectionProperties[index + 1].Split(',').ToList();
                     string shape = split[14].Trim();
                     string interpolationOrder = Math.Max(System.Convert.ToInt32(split[15].Trim()), System.Convert.ToInt32(split[16].Trim())).ToString();
@@ -212,8 +219,6 @@ namespace BH.Adapter.MidasCivil
                     i = iEnd;
                 }
             }
-
-
 
             return bhomSectionProperties;
         }

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -43,9 +43,24 @@ namespace BH.Adapter.MidasCivil
 
             List<string> sectionProperties = GetSectionText("SECTION");
 
+            List<string> types = new List<string>() { "VALUE", "DBUSER", "TAPERED", "SRC", "COMBINED", "PSC", "COMPOSITE", "SOD", "COMBINED" };
+
+            List<int> indexes = new List<int>();
+
+            // Determine where the section starts based on the keyword types above occuring in the [1] position
             for (int i = 0; i < sectionProperties.Count; i++)
             {
-                string sectionProperty = sectionProperties[i];
+                string line = sectionProperties[i];
+                if(!(line.Length < 2))
+                {
+                    if (types.Any(x => x == sectionProperties[i].Split(',')[1].Trim()))
+                        indexes.Add(i);
+                }
+            }
+
+            foreach (int index in indexes)
+            {
+                string sectionProperty = sectionProperties[index];
                 string type = sectionProperty.Split(',')[1].Trim();
 
                 ISectionProperty bhomSectionProperty = null;
@@ -53,9 +68,9 @@ namespace BH.Adapter.MidasCivil
                 if (type == "VALUE")
                 {
                     string sectionProfile = sectionProperty;
-                    string sectionProperties1 = sectionProperties[i + 1];
-                    string sectionProperties2 = sectionProperties[i + 2];
-                    string sectionProperties3 = sectionProperties[i + 3];
+                    string sectionProperties1 = sectionProperties[index + 1];
+                    string sectionProperties2 = sectionProperties[index + 2];
+                    string sectionProperties3 = sectionProperties[index + 3];
 
                     List<string> split = sectionProfile.Split(',').ToList();
 
@@ -65,8 +80,6 @@ namespace BH.Adapter.MidasCivil
 
                     bhomSectionProperty.Name = split[2].Trim();
                     bhomSectionProperty.SetAdapterId(typeof(MidasCivilId), split[0].Trim());
-
-                    i = i + 3;
                 }
                 else if (type == "DBUSER")
                 {
@@ -89,7 +102,7 @@ namespace BH.Adapter.MidasCivil
                 else if (type == "TAPERED")
                 {
                     List<string> split = sectionProperty.Split(',').ToList();
-                    List<string> profiles = sectionProperties[i + 1].Split(',').ToList();
+                    List<string> profiles = sectionProperties[index + 1].Split(',').ToList();
                     string shape = split[14].Trim();
                     string interpolationOrder = Math.Max(System.Convert.ToInt32(split[15].Trim()), System.Convert.ToInt32(split[16].Trim())).ToString();
 
@@ -97,12 +110,10 @@ namespace BH.Adapter.MidasCivil
 
                     bhomSectionProperty.SetAdapterId(typeof(MidasCivilId), split[0].Trim());
                     bhomSectionProperty.Name = split[2].Trim();
-
-                    i = i + 1;
                 }
                 else
                 {
-                    Engine.Base.Compute.RecordWarning(type + " not supported in the MidasCivil_Toolkit");
+                    Engine.Base.Compute.RecordWarning(type + " is not supported in the MidasCivil_Toolkit - a null value will be assigned to any Bars referencing it.");
                 }
 
                 if (bhomSectionProperty != null)
@@ -195,9 +206,9 @@ namespace BH.Adapter.MidasCivil
                     //Set i index for next section property
                     i = iEnd;
                 }
-                else if(type == "COMPOSITE-GEN")
+                else
                 {
-                    Engine.Base.Compute.RecordWarning("MidasCivil_Toolkit does not support COMPOSITE-GEN sections, this section has been skipped.");
+                    Engine.Base.Compute.RecordWarning(type + " is not supported in the MidasCivil_Toolkit - a null value will be assigned to any Bars referencing it.");
                     i = iEnd;
                 }
             }

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToMaterials.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToMaterials.cs
@@ -41,7 +41,8 @@ namespace BH.Adapter.Adapters.MidasCivil
             string name = delimited[2].Trim();
             IMaterialFragment bhomMaterial = null;
 
-            bhomMaterial = (IMaterialFragment)Engine.Library.Query.Match("Structure\\Materials", name);
+            // delimitted[12] is the database name of the material
+            bhomMaterial = (IMaterialFragment)Engine.Library.Query.Match("Structure\\Materials", delimited[12].Trim());
 
             double density = 0;
 
@@ -114,9 +115,9 @@ namespace BH.Adapter.Adapters.MidasCivil
                         }
                         break;
                     case "STEEL":
-                        if (delimited.Count() == 15)
+                        if ((delimited[9].Trim()) == "2") // 2 is for user defined materials, database sections do not include material properties in the MCT
                         {
-                            bhomMaterial = (IMaterialFragment)Engine.Structure.Create.Steel(
+                            bhomMaterial = Engine.Structure.Create.Steel(
                                 name,
                                 double.Parse(delimited[10].Trim()).PressureToSI(forceUnit, lengthUnit),
                                 double.Parse(delimited[11].Trim()),
@@ -127,15 +128,14 @@ namespace BH.Adapter.Adapters.MidasCivil
                         }
                         else
                         {
-                            Engine.Base.Compute.RecordWarning("Material not found in BHoM Library: S355 Steel properties assumed");
-                            bhomMaterial = (IMaterialFragment)BH.Engine.Library.Query.Match("Structure\\Materials", "S355");
+                            Engine.Base.Compute.RecordWarning(name + " not found in BHoM Library, a null value has been assigned.");
                         }
                         break;
 
                     case "CONC":
-                        if (delimited.Count() == 15)
+                        if ((delimited[9].Trim()) == "2") // 2 is for user defined materials, database sections do not include material properties in the MCT
                         {
-                            bhomMaterial = (IMaterialFragment)Engine.Structure.Create.Concrete(
+                            bhomMaterial = Engine.Structure.Create.Concrete(
                                 name,
                                 double.Parse(delimited[10].Trim()).PressureToSI(forceUnit, lengthUnit),
                                 double.Parse(delimited[11].Trim()),
@@ -147,16 +147,18 @@ namespace BH.Adapter.Adapters.MidasCivil
                         }
                         else
                         {
-                            Engine.Base.Compute.RecordWarning("Material not found in BHoM Library.");
+                            Engine.Base.Compute.RecordWarning(name + " not found in BHoM Library, a null value has been assigned.");
                         }
                         break;
                     case "SRC":
-                        Engine.Base.Compute.RecordError("BHoM does not support Reinforced Concrete Sections");
+                        Engine.Base.Compute.RecordWarning("BHoM does not support Reinforced Concrete Sections and a null section has been assigned.");
                         break;
                 }
             }
 
-            bhomMaterial.SetAdapterId(typeof(MidasCivilId), delimited[0].Trim());
+            if (bhomMaterial != null)
+                bhomMaterial.SetAdapterId(typeof(MidasCivilId), delimited[0].Trim());
+
             return bhomMaterial;
         }
 

--- a/MidasCivil_Adapter/PrivateHelpers/GetSectionMaterialCombinations.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/GetSectionMaterialCombinations.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.MidasCivil
                 materials.TryGetValue(materialId.ToString(), out material);
                 sectionProperties.TryGetValue(sectionPropertyId.ToString(), out section);
 
-                if(section is SteelSection || section is ConcreteSection || section is AluminiumSection || section is TimberSection)
+                if (section is SteelSection || section is ConcreteSection || section is AluminiumSection || section is TimberSection)
                 {
                     materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), section);
                 }
@@ -60,49 +60,57 @@ namespace BH.Adapter.MidasCivil
                     //Needed to get the ShapeProfile
                     GenericSection genericSection = (GenericSection)section;
 
-                    switch (material.GetType().ToString().Split('.').Last())
+                    if (section != null  && material != null)
                     {
-                        case "Concrete":
-                            ConcreteSection concreteSection = Engine.Structure.Create.ConcreteSectionFromProfile(genericSection.SectionProfile, (Concrete)material);
-                            concreteSection.Name = genericSection.Name;
-                            concreteSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
-                            materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), concreteSection);
-                            break;
-                        case "Steel":
-                            SteelSection steelSection = Engine.Structure.Create.SteelSectionFromProfile(genericSection.SectionProfile, (Steel)material);
-                            steelSection.Name = genericSection.Name;
-                            steelSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
-                            materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), steelSection);
-                            break;
-                        case "Aluminium":
-                            AluminiumSection aluminiumSection = Engine.Structure.Create.AluminiumSectionFromProfile(genericSection.SectionProfile, (Aluminium)material);
-                            aluminiumSection.Name = genericSection.Name;
-                            aluminiumSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
-                            materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), aluminiumSection);
-                            break;
-                        case "Timber":
-                            TimberSection timberSection = Engine.Structure.Create.TimberSectionFromProfile(genericSection.SectionProfile, (Timber)material);
-                            timberSection.Name = genericSection.Name;
-                            timberSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
-                            materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
-                            break;
-                        case "GenericIsotropicMaterial":
-                            GenericSection genericIsoptropicSection =
-                                Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericIsotropicMaterial)material);
-                            genericIsoptropicSection.Name = genericSection.Name;
-                            genericIsoptropicSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
-                            materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericIsoptropicSection);
-                            break;
-                        case "GenericOrthotropicMaterial":
-                            GenericSection genericOrthotropicSection =
-                                Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericOrthotropicMaterial)material);
-                            genericOrthotropicSection.Name = genericSection.Name;
-                            genericOrthotropicSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
-                            materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericOrthotropicSection);
-                            break;
-                        default:
-                            Engine.Base.Compute.RecordError(material.GetType().ToString().Split('.').Last() + "not recognised");
-                            break;
+                        switch (material.GetType().ToString().Split('.').Last())
+                        {
+                            case "Concrete":
+                                ConcreteSection concreteSection = Engine.Structure.Create.ConcreteSectionFromProfile(genericSection.SectionProfile, (Concrete)material);
+                                concreteSection.Name = genericSection.Name;
+                                concreteSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
+                                materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), concreteSection);
+                                break;
+                            case "Steel":
+                                SteelSection steelSection = Engine.Structure.Create.SteelSectionFromProfile(genericSection.SectionProfile, (Steel)material);
+                                steelSection.Name = genericSection.Name;
+                                steelSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
+                                materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), steelSection);
+                                break;
+                            case "Aluminium":
+                                AluminiumSection aluminiumSection = Engine.Structure.Create.AluminiumSectionFromProfile(genericSection.SectionProfile, (Aluminium)material);
+                                aluminiumSection.Name = genericSection.Name;
+                                aluminiumSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
+                                materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), aluminiumSection);
+                                break;
+                            case "Timber":
+                                TimberSection timberSection = Engine.Structure.Create.TimberSectionFromProfile(genericSection.SectionProfile, (Timber)material);
+                                timberSection.Name = genericSection.Name;
+                                timberSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
+                                materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), timberSection);
+                                break;
+                            case "GenericIsotropicMaterial":
+                                GenericSection genericIsoptropicSection =
+                                    Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericIsotropicMaterial)material);
+                                genericIsoptropicSection.Name = genericSection.Name;
+                                genericIsoptropicSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
+                                materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericIsoptropicSection);
+                                break;
+                            case "GenericOrthotropicMaterial":
+                                GenericSection genericOrthotropicSection =
+                                    Engine.Structure.Create.GenericSectionFromProfile(genericSection.SectionProfile, (GenericOrthotropicMaterial)material);
+                                genericOrthotropicSection.Name = genericSection.Name;
+                                genericOrthotropicSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
+                                materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericOrthotropicSection);
+                                break;
+                            default:
+                                Engine.Base.Compute.RecordError(material.GetType().ToString().Split('.').Last() + "not recognised");
+                                break;
+                        }
+                    }
+                    else if(section != null)
+                    {
+                        genericSection.SetAdapterId(typeof(MidasCivilId), sectionPropertyId);
+                        materialSections.Add(materialId.ToString() + "," + sectionPropertyId.ToString(), genericSection);
                     }
                 }
 


### PR DESCRIPTION

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #356 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23356%20Custom%20Sections%20Not%20Supported?csf=1&web=1&e=OQFqUA

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Changed the way `SectionProperties` are read to capture unsupported sections from MidasCivil.
- Improved the database searching when pulling database `SectionProperty` and `IMaterialFragment` from MidasCivil

### Additional comments
<!-- As required -->