### PR TITLE
Fix bug where SectionProperty ids were not sequential for multiple pushes

### DIFF
--- a/MidasCivil_Adapter/Type/NextFreeId.cs
+++ b/MidasCivil_Adapter/Type/NextFreeId.cs
@@ -131,21 +131,18 @@ namespace BH.Adapter.MidasCivil
                     string section = "SECTION";
                     string pscSection = "SECT-PSCVALUE";
 
-                    int sectionIndex = 0;
-                    int pscSectionIndex = 0;
-
                     if (ExistsSection(section) && ExistsSection(pscSection))
                     {
-                        sectionIndex = Math.Max(GetMaxId(section), GetMaxId(pscSection));
+                        index = Math.Max(GetMaxId(section), GetMaxId(pscSection)) + 1;
                     }
                     else if (ExistsSection(section))
                     {
-                        pscSectionIndex = GetMaxId(section);
+                        index = GetMaxId(section) + 1;
 
                     }
                     else if (ExistsSection(pscSection))
                     {
-                        pscSectionIndex = GetMaxId(pscSection);
+                        index = GetMaxId(pscSection) + 1;
 
                     }
                     else


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #359 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23359-SectionPropertyIdBug.gh?csf=1&web=1&e=iWCRtf

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed bug where `SectionProperty` objects did not have sequential ids when using multiple push components, leading to errors when trying to read them in to a `Dictionary`.

### Additional comments
<!-- As required -->