### PR TITLE
Changing how SurfaceProperty Name is handled for MidasCivil 2020 v3.2

### DIFF
--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
@@ -61,8 +61,13 @@ namespace BH.Adapter.Adapters.MidasCivil
                     constantThickness = new ConstantThickness
                     {
                         Thickness = System.Convert.ToDouble(split[4].Trim()).LengthToSI(lengthUnit),
-                        Name = "t = " + split[4].Trim()
                     };
+
+                    if (split[2].Trim() != "1")
+                        constantThickness.Name = split[2].Trim();
+                    else
+                        constantThickness.Name = "t = " + split[4].Trim();
+
                     break;
             }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSurfaceProperty.cs
@@ -72,7 +72,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                         break;
                     default:
                         midasSurfaceProperty =
-                            bhomSurfaceProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE,1,Yes," +
+                            bhomSurfaceProperty.AdapterId<string>(typeof(MidasCivilId)) + ",VALUE," + new string(bhomSurfaceProperty.DescriptionOrName().Replace(",", "").Take(groupCharacterLimit).ToArray()) + ",Yes," +
                             bhomSurfaceProperty.Thickness.LengthFromSI(lengthUnit) + ",0,No,0,0";
                         break;
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #361 

<!-- Add short description of what has been fixed -->
Changed how `SurfaceProperty` names are read from MidasCivil

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23361%20CreateNonExisting?csf=1&web=1&e=JVUdLf

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug whereby `SurfaceProperty` names were not being read from MidasCivil.


### Additional comments
<!-- As required -->