### PR TITLE
Fixed bug where SaveAs command caused an error

### DIFF
--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -114,10 +114,10 @@ namespace BH.Adapter.MidasCivil
             Directory.CreateDirectory(newDirectory);
             string[] mcbFiles = Directory.GetFiles(m_directory, "*.mcb");
             foreach (string mcbFile in mcbFiles)
-                File.Copy(mcbFile, newDirectory);
+                File.Copy(mcbFile, Path.Combine(newDirectory, command.FileName + ".mcb"));
             string[] mctFiles = Directory.GetFiles(m_directory, "*.mcb");
             foreach (string mctFile in mctFiles)
-                File.Copy(mctFile, newDirectory);
+                File.Copy(mctFile, Path.Combine(newDirectory, command.FileName + ".mct"));
             CopyAll(new DirectoryInfo(m_directory + "\\TextFiles"), new DirectoryInfo(newDirectory + "\\TextFiles"));
             CopyAll(new DirectoryInfo(m_directory + "\\Results"), new DirectoryInfo(newDirectory + "\\Results"));
 

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -103,7 +103,8 @@ namespace BH.Adapter.MidasCivil
 
         public bool RunCommand(SaveAs command)
         {
-            string newDirectory = GetDirectoryRoot(m_directory) + "\\" + command.FileName;
+            string fileName = command.FileName;
+            string newDirectory = GetDirectoryRoot(m_directory) + "\\" + fileName;
 
             if (Directory.Exists(newDirectory))
             {
@@ -114,10 +115,10 @@ namespace BH.Adapter.MidasCivil
             Directory.CreateDirectory(newDirectory);
             string[] mcbFiles = Directory.GetFiles(m_directory, "*.mcb");
             foreach (string mcbFile in mcbFiles)
-                File.Copy(mcbFile, Path.Combine(newDirectory, command.FileName + ".mcb"));
+                File.Copy(mcbFile, Path.Combine(newDirectory, fileName + ".mcb"));
             string[] mctFiles = Directory.GetFiles(m_directory, "*.mcb");
             foreach (string mctFile in mctFiles)
-                File.Copy(mctFile, Path.Combine(newDirectory, command.FileName + ".mct"));
+                File.Copy(mctFile, Path.Combine(newDirectory, fileName + ".mct"));
             CopyAll(new DirectoryInfo(m_directory + "\\TextFiles"), new DirectoryInfo(newDirectory + "\\TextFiles"));
             CopyAll(new DirectoryInfo(m_directory + "\\Results"), new DirectoryInfo(newDirectory + "\\Results"));
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

The copying of the `.mcb` and `.mct` file when using the `SaveAs` command did not work. It used the wrong input for the `File.Copy(string, string)`. The second string pointed to a `directory` rather than a `destination file`.

This made it so the `.mcb` and `.mct` file was not copied.
The issue also resulted in the issue stated in #289 which this closes.
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #289 
<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->

Please use the test script below and run the execute workflow.
Before testing
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&web=1&e=bdWLDi&cid=c70586d3%2Df382%2D473f%2Dab89%2Db962fae9a4aa&RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FMidasCivil%5FToolkit%2F%23289%2DSaveAsNotWorking&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4

