### PR TITLE
Fix a bug where REBAR-MATL-CODE creates an error when running mct file

### DIFF
--- a/MidasCivil_Engine/Compute/CombineTextFiles.cs
+++ b/MidasCivil_Engine/Compute/CombineTextFiles.cs
@@ -95,6 +95,8 @@ namespace BH.Engine.Adapters.MidasCivil
                     typeNames.Remove("LOADCASE");
                 }
 
+                //Add a check for Rebar and inclusion of nodes or sections here. If nodes or sections exist. remove. Rebar info?
+
                 // Check type dependencies to see if valid
 
                 List<string> independents = new List<string> { "NODE", "ELEMENT", "MATERIAL", "SECTION", "STLDCASE" };
@@ -123,7 +125,10 @@ namespace BH.Engine.Adapters.MidasCivil
                     }
                 }
 
-                independents.Insert(0, "REBAR-MATL-CODE");
+                if (!typeNames.Contains("NODE") || !typeNames.Contains("SECTION"))
+                    typeNames.Remove("REBAR-MATL-CODE");
+                else
+                    independents.Insert(0, "REBAR-MATL-CODE");
                 independents.Add("LOAD-GROUP");
                 independents.Add("LOADCOMB");
 

--- a/MidasCivil_Engine/Compute/CombineTextFiles.cs
+++ b/MidasCivil_Engine/Compute/CombineTextFiles.cs
@@ -95,8 +95,6 @@ namespace BH.Engine.Adapters.MidasCivil
                     typeNames.Remove("LOADCASE");
                 }
 
-                //Add a check for Rebar and inclusion of nodes or sections here. If nodes or sections exist. remove. Rebar info?
-
                 // Check type dependencies to see if valid
 
                 List<string> independents = new List<string> { "NODE", "ELEMENT", "MATERIAL", "SECTION", "STLDCASE" };

--- a/MidasCivil_Engine/Compute/CombineTextFiles.cs
+++ b/MidasCivil_Engine/Compute/CombineTextFiles.cs
@@ -123,10 +123,8 @@ namespace BH.Engine.Adapters.MidasCivil
                     }
                 }
 
-                if (!typeNames.Contains("NODE") || !typeNames.Contains("SECTION"))
-                    typeNames.Remove("REBAR-MATL-CODE");
-                else
-                    independents.Insert(0, "REBAR-MATL-CODE");
+                independents.Insert(0, "REBAR-MATL-CODE");
+                independents.Insert(1, "STRUCTYPE");
                 independents.Add("LOAD-GROUP");
                 independents.Add("LOADCOMB");
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #180 

Fix bug where mct file failes to run with error message. 
> Error has been encountered during the data input. : *The command of REBAR-MATL-CODE cannot be executed when nodes or sections are included in the model.
> Run Error : command in line 8-10

Fixed by not including REBAR-MATL-CODE when nodes or sections are included. 

### Test files
<!-- Link to test files to validate the proposed changes -->

- Very simple push and combine script. 
- MidasCivil file with one node existing. 

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23373-FixBugWithMctFailsToParse?csf=1&web=1&e=vm1gbm