### PR TITLE
Remove FixFix exception and remove bug for partial matches

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Elements/Element.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter.MidasCivil
                     Engine.Base.Compute.RecordError("Tension only elements cannot support bar releases in Midas");
                 }
 
-                if (!(bar.Release == null) && new string(bar.Release.DescriptionOrName().Replace(",", "").Take(m_groupCharacterLimit).ToArray()) != "FixFix")
+                if (!(bar.Release == null))
                 {
                     AssignBarRelease(bar.AdapterId<string>(typeof(MidasCivilId)), new string(bar.Release.DescriptionOrName().Replace(",", "").Take(m_groupCharacterLimit).ToArray()), "FRAME-RLS");
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Properties/BarReleases.cs
@@ -42,15 +42,14 @@ namespace BH.Adapter.MidasCivil
 
             foreach (BarRelease release in releases)
             {
-                if (release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToString() != "FixFix")
-                {
                     string midasBoundaryGroup = Adapters.MidasCivil.Convert.FromTag(new string(release.DescriptionOrName().Replace(",","").Take(m_groupCharacterLimit).ToArray()));
                     CompareGroup(midasBoundaryGroup, boundaryGroupPath);
                     midasBarReleases.AddRange(Adapters.MidasCivil.Convert.FromBarRelease(release, m_groupCharacterLimit));
-                }
             }
 
             File.AppendAllLines(path, midasBarReleases);
+
+
 
             return true;
         }

--- a/MidasCivil_Adapter/PrivateHelpers/AssignBarRelease.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/AssignBarRelease.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.MidasCivil
 
             List<string> propertyText = File.ReadAllLines(path).ToList();
 
-            int index = propertyText.FindIndex(x => x.Contains(propertyName)) - 1;
+            int index = propertyText.FindIndex(x => x.Contains("," + propertyName)) - 1; //"," added to prevent any partial matches
 
             string constraint = propertyText[index];
 
@@ -89,7 +89,3 @@ namespace BH.Adapter.MidasCivil
 
     }
 }
-
-
-
-


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #375 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23375-FRAME-RLS.gh?csf=1&web=1&e=Uyp9b0

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removed code that would filter `FixFix` `BarRelease` and result in empty `BarRelease`s being pushed to MidasCivil, this would result in a warning
- Fixed a bug whereby partial matches would result in the incorrect assignments of BarReleases

### Additional comments
<!-- As required -->