### PR TITLE
Shallow clone BarVaryingDistributedLoad so the returned objects are not modified

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/AreaUniformlyDistributedLoads.cs
@@ -22,6 +22,7 @@
 
 using BH.oM.Adapters.MidasCivil;
 using BH.Engine.Adapter;
+using BH.Engine.Base;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
@@ -38,11 +39,12 @@ namespace BH.Adapter.MidasCivil
 
             foreach (AreaUniformlyDistributedLoad areaUniformlyDistributedLoad in areaUniformlyDistributedLoads)
             {
+                AreaUniformlyDistributedLoad load = areaUniformlyDistributedLoad.ShallowClone();
                 List<string> midasPressureLoads = new List<string>();
-                string FEMeshLoadPath = CreateSectionFile(areaUniformlyDistributedLoad.Loadcase.Name + "\\PRESSURE");
+                string FEMeshLoadPath = CreateSectionFile(load.Loadcase.Name + "\\PRESSURE");
                 string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(areaUniformlyDistributedLoad);
 
-                List<IAreaElement> assignedElements = areaUniformlyDistributedLoad.Objects.Elements;
+                List<IAreaElement> assignedElements = load.Objects.Elements;
 
                 List<string> assignedFEMeshes = new List<string>();
 
@@ -55,23 +57,23 @@ namespace BH.Adapter.MidasCivil
                     }
                 }
 
-                List<double> loadVectors = new List<double> { areaUniformlyDistributedLoad.Pressure.X,
-                                                              areaUniformlyDistributedLoad.Pressure.Y,
-                                                              areaUniformlyDistributedLoad.Pressure.Z};
+                List<double> loadVectors = new List<double> { load.Pressure.X,
+                                                              load.Pressure.Y,
+                                                              load.Pressure.Z};
 
                 Vector zeroVector = new Vector { X = 0, Y = 0, Z = 0 };
 
                 for (int i = 0; i < 3; i++)
                 {
-                    areaUniformlyDistributedLoad.Pressure = zeroVector;
+                    load.Pressure = zeroVector;
 
                     if (loadVectors[i] != 0)
                     {
-                        areaUniformlyDistributedLoad.Pressure = CreateSingleComponentVector(i, loadVectors[i]);
+                        load.Pressure = CreateSingleComponentVector(i, loadVectors[i]);
 
                         foreach (string assignedFEMesh in assignedFEMeshes)
                         {
-                            midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(areaUniformlyDistributedLoad, assignedFEMesh, m_midasCivilVersion, m_forceUnit, m_lengthUnit));
+                            midasPressureLoads.Add(Adapters.MidasCivil.Convert.FromAreaUniformlyDistributedLoad(load, assignedFEMesh, m_midasCivilVersion, m_forceUnit, m_lengthUnit));
                         }
                     }
                 }

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
@@ -24,6 +24,7 @@ using BH.oM.Adapters.MidasCivil;
 using BH.oM.Structure.Loads;
 using BH.oM.Geometry;
 using BH.Engine.Adapter;
+using BH.Engine.Base;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,35 +43,36 @@ namespace BH.Adapter.MidasCivil
 
             foreach (BarPointLoad barPointLoad in barPointLoads)
             {
+                BarPointLoad load = barPointLoad.ShallowClone();
                 List<string> midasBarLoads = new List<string>();
-                string barLoadPath = CreateSectionFile(barPointLoad.Loadcase.Name + "\\BEAMLOAD");
+                string barLoadPath = CreateSectionFile(load.Loadcase.Name + "\\BEAMLOAD");
                 string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(barPointLoad);
 
                 List<string> assignedBars = barPointLoad.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
 
-                List<double> loadVectors = new List<double> { barPointLoad.Force.X,
-                                                              barPointLoad.Force.Y,
-                                                              barPointLoad.Force.Z,
-                                                              barPointLoad.Moment.X,
-                                                              barPointLoad.Moment.Y,
-                                                              barPointLoad.Moment.Z};
+                List<double> loadVectors = new List<double> { load.Force.X,
+                                                              load.Force.Y,
+                                                              load.Force.Z,
+                                                              load.Moment.X,
+                                                              load.Moment.Y,
+                                                              load.Moment.Z};
 
                 Vector zeroVector = new Vector { X = 0, Y = 0, Z = 0 };
 
                 for (int i = 0; i < 6; i++)
                 {
-                    barPointLoad.Force = zeroVector;
-                    barPointLoad.Moment = zeroVector;
+                    load.Force = zeroVector;
+                    load.Moment = zeroVector;
 
                     if (loadVectors[i] != 0)
                     {
                         if (i < 3)
                         {
-                            barPointLoad.Force = CreateSingleComponentVector(i, loadVectors[i]);
+                            load.Force = CreateSingleComponentVector(i, loadVectors[i]);
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(barPointLoad, assignedBar, "Force", m_forceUnit, m_lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(load, assignedBar, "Force", m_forceUnit, m_lengthUnit));
                             }
                         }
                         else
@@ -79,7 +81,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(barPointLoad, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarPointLoad(load, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
                             }
                         }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
@@ -72,7 +72,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(barUniformlyDistributedLoad, assignedBar, "Force", m_forceUnit, m_lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(load, assignedBar, "Force", m_forceUnit, m_lengthUnit));
                             }
                         }
                         else
@@ -81,7 +81,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(barUniformlyDistributedLoad, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarUniformlyDistributedLoad(load, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
                             }
                         }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarUniformlyDistributedLoads.cs
@@ -27,6 +27,7 @@ using BH.oM.Geometry;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using BH.Engine.Base;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -42,31 +43,32 @@ namespace BH.Adapter.MidasCivil
 
             foreach (BarUniformlyDistributedLoad barUniformlyDistributedLoad in barUniformlyDistributedLoads)
             {
+                BarUniformlyDistributedLoad load = barUniformlyDistributedLoad.ShallowClone();
                 List<string> midasBarLoads = new List<string>();
-                string barLoadPath = CreateSectionFile(barUniformlyDistributedLoad.Loadcase.Name + "\\BEAMLOAD");
+                string barLoadPath = CreateSectionFile(load.Loadcase.Name + "\\BEAMLOAD");
                 string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(barUniformlyDistributedLoad);
 
-                List<string> assignedBars = barUniformlyDistributedLoad.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
+                List<string> assignedBars = load.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
 
-                List<double> loadVectors = new List<double> { barUniformlyDistributedLoad.Force.X,
-                                                              barUniformlyDistributedLoad.Force.Y,
-                                                              barUniformlyDistributedLoad.Force.Z,
-                                                              barUniformlyDistributedLoad.Moment.X,
-                                                              barUniformlyDistributedLoad.Moment.Y,
-                                                              barUniformlyDistributedLoad.Moment.Z};
+                List<double> loadVectors = new List<double> { load.Force.X,
+                                                              load.Force.Y,
+                                                              load.Force.Z,
+                                                              load.Moment.X,
+                                                              load.Moment.Y,
+                                                              load.Moment.Z};
 
                 Vector zeroVector = new Vector { X = 0, Y = 0, Z = 0 };
 
                 for (int i = 0; i < 6; i++)
                 {
-                    barUniformlyDistributedLoad.Force = zeroVector;
-                    barUniformlyDistributedLoad.Moment = zeroVector;
+                    load.Force = zeroVector;
+                    load.Moment = zeroVector;
 
                     if (loadVectors[i] != 0)
                     {
                         if (i < 3)
                         {
-                            barUniformlyDistributedLoad.Force = CreateSingleComponentVector(i, loadVectors[i]);
+                            load.Force = CreateSingleComponentVector(i, loadVectors[i]);
 
                             foreach (string assignedBar in assignedBars)
                             {
@@ -75,7 +77,7 @@ namespace BH.Adapter.MidasCivil
                         }
                         else
                         {
-                            barUniformlyDistributedLoad.Moment = CreateSingleComponentVector(i - 3, loadVectors[i]);
+                            load.Moment = CreateSingleComponentVector(i - 3, loadVectors[i]);
 
                             foreach (string assignedBar in assignedBars)
                             {

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
@@ -94,7 +94,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(barVaryingDistributedLoad, assignedBar, "Force", m_forceUnit, m_lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(load, assignedBar, "Force", m_forceUnit, m_lengthUnit));
                             }
                         }
                         else
@@ -104,7 +104,7 @@ namespace BH.Adapter.MidasCivil
 
                             foreach (string assignedBar in assignedBars)
                             {
-                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(barVaryingDistributedLoad, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
+                                midasBarLoads.Add(Adapters.MidasCivil.Convert.FromBarVaryingDistributedLoad(load, assignedBar, "Moment", m_forceUnit, m_lengthUnit));
                             }
                         }
 

--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarVaryingDistributedLoads.cs
@@ -27,6 +27,7 @@ using BH.oM.Geometry;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using BH.Engine.Base;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -42,53 +43,54 @@ namespace BH.Adapter.MidasCivil
 
             foreach (BarVaryingDistributedLoad barVaryingDistributedLoad in barVaryingDistributedLoads)
             {
-                if (!barVaryingDistributedLoad.RelativePositions)
+                BarVaryingDistributedLoad load = barVaryingDistributedLoad.ShallowClone();
+                if (!load.RelativePositions)
                 {
                     Engine.Base.Compute.RecordError("The midas adapter can only handle BarVaryingDistributedLoads with relative positions. Please update the loads to be set with this format.");
                     continue;
                 }
 
-                if (barVaryingDistributedLoad.StartPosition >= barVaryingDistributedLoad.EndPosition)
+                if (load.StartPosition >= load.EndPosition)
                 {
                     Engine.Base.Compute.RecordError("Midas civil only supports start positions less than end positions for BarVaryingDistributedLoads.");
                     continue;
                 }
 
                 List<string> midasBarLoads = new List<string>();
-                string barLoadPath = CreateSectionFile(barVaryingDistributedLoad.Loadcase.Name + "\\BEAMLOAD");
-                string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(barVaryingDistributedLoad);
+                string barLoadPath = CreateSectionFile(load.Loadcase.Name + "\\BEAMLOAD");
+                string midasLoadGroup = Adapters.MidasCivil.Convert.FromLoadGroup(load);
 
-                List<string> assignedBars = barVaryingDistributedLoad.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
+                List<string> assignedBars = load.Objects.Elements.Select(x => x.AdapterId<string>(typeof(MidasCivilId))).ToList();
 
-                List<double> startLoadVectors = new List<double> { barVaryingDistributedLoad.ForceAtStart.X,
-                                                              barVaryingDistributedLoad.ForceAtStart.Y,
-                                                              barVaryingDistributedLoad.ForceAtStart.Z,
-                                                              barVaryingDistributedLoad.MomentAtStart.X,
-                                                              barVaryingDistributedLoad.MomentAtStart.Y,
-                                                              barVaryingDistributedLoad.MomentAtStart.Z};
+                List<double> startLoadVectors = new List<double> { load.ForceAtStart.X,
+                                                              load.ForceAtStart.Y,
+                                                              load.ForceAtStart.Z,
+                                                              load.MomentAtStart.X,
+                                                              load.MomentAtStart.Y,
+                                                              load.MomentAtStart.Z};
 
-                List<double> endLoadVectors = new List<double> { barVaryingDistributedLoad.ForceAtEnd.X,
-                                                              barVaryingDistributedLoad.ForceAtEnd.Y,
-                                                              barVaryingDistributedLoad.ForceAtEnd.Z,
-                                                              barVaryingDistributedLoad.MomentAtEnd.X,
-                                                              barVaryingDistributedLoad.MomentAtEnd.Y,
-                                                              barVaryingDistributedLoad.MomentAtEnd.Z};
+                List<double> endLoadVectors = new List<double> { load.ForceAtEnd.X,
+                                                              load.ForceAtEnd.Y,
+                                                              load.ForceAtEnd.Z,
+                                                              load.MomentAtEnd.X,
+                                                              load.MomentAtEnd.Y,
+                                                              load.MomentAtEnd.Z};
 
                 Vector zeroVector = new Vector { X = 0, Y = 0, Z = 0 };
 
                 for (int i = 0; i < 6; i++)
                 {
-                    barVaryingDistributedLoad.ForceAtStart = zeroVector;
-                    barVaryingDistributedLoad.MomentAtStart = zeroVector;
-                    barVaryingDistributedLoad.ForceAtEnd = zeroVector;
-                    barVaryingDistributedLoad.MomentAtEnd = zeroVector;
+                    load.ForceAtStart = zeroVector;
+                    load.MomentAtStart = zeroVector;
+                    load.ForceAtEnd = zeroVector;
+                    load.MomentAtEnd = zeroVector;
 
                     if (!(startLoadVectors[i] == 0 && endLoadVectors[i] == 0))
                     {
                         if (i < 3)
                         {
-                            barVaryingDistributedLoad.ForceAtStart = CreateSingleComponentVector(i, startLoadVectors[i]);
-                            barVaryingDistributedLoad.ForceAtEnd = CreateSingleComponentVector(i, endLoadVectors[i]);
+                            load.ForceAtStart = CreateSingleComponentVector(i, startLoadVectors[i]);
+                            load.ForceAtEnd = CreateSingleComponentVector(i, endLoadVectors[i]);
 
                             foreach (string assignedBar in assignedBars)
                             {
@@ -97,8 +99,8 @@ namespace BH.Adapter.MidasCivil
                         }
                         else
                         {
-                            barVaryingDistributedLoad.MomentAtStart = CreateSingleComponentVector(i - 3, startLoadVectors[i]);
-                            barVaryingDistributedLoad.MomentAtEnd = CreateSingleComponentVector(i - 3, endLoadVectors[i]);
+                            load.MomentAtStart = CreateSingleComponentVector(i - 3, startLoadVectors[i]);
+                            load.MomentAtEnd = CreateSingleComponentVector(i - 3, endLoadVectors[i]);
 
                             foreach (string assignedBar in assignedBars)
                             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #274 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[#274 BarVaryingDistributedLoad](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/MidasCivil_Toolkit/%23274%20BarVaryingDistributedLoad.gh?csf=1&web=1&e=XaNAnJ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Changed how `BarVaryingDistributedLoads` are created  to remove any modification of the base object;
