### PR TITLE
Add import action for Midas Civil NX

### DIFF
--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -32,6 +32,7 @@ using BH.oM.Structure.Loads;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 
 namespace BH.Adapter.MidasCivil
 {
@@ -319,20 +320,43 @@ namespace BH.Adapter.MidasCivil
         }
 
         /***************************************************/
-        public async Task<bool> RunCommand(Import command)
+        public async Task<bool> RunCommand(ImportFile command)
         {
             if (m_midasCivilVersion == "9.5.0.nx")
             {
+                string endpoint = "";
                 string filePath = command.FilePath;
-                if (File.Exists(filePath))
-                    filePath = filePath.Replace("\\", "\\\\");
-                else
-                    Engine.Base.Compute.RecordError("The given file path does not exist.");
 
-                string endpoint = "doc/IMPORTMXT";
+                if (File.Exists(filePath))
+                {
+                    string extension = Path.GetExtension(filePath).ToLower();
+
+                    if (extension == ".mct" || extension == ".mgt" || extension == ".txt")
+                        endpoint = "doc/IMPORTMXT";
+
+                    else if (extension == ".json")
+                        endpoint = "doc/IMPORT";
+
+                    else
+                    {
+                        Engine.Base.Compute.RecordError("The given file type is not supported by this Adapter.");
+                        return false;
+                    }
+
+                }
+
+                else
+                {
+                    Engine.Base.Compute.RecordError("The given file path does not exist.");
+                    return false;
+                }
+
+                filePath = filePath.Replace("\\", "\\\\");
+
                 string jsonPayload = "{\"Argument\": \"" + filePath + "\"}";
 
                 await SendRequestAsync(endpoint, HttpMethod.Post, jsonPayload).ConfigureAwait(false);
+
                 return true;
             }
 

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -319,6 +319,29 @@ namespace BH.Adapter.MidasCivil
         }
 
         /***************************************************/
+        public async Task<bool> RunCommand(Import command)
+        {
+            if (m_midasCivilVersion == "9.5.0.nx")
+            {
+                string filePath = command.FilePath;
+                if (File.Exists(filePath))
+                    filePath = filePath.Replace("\\", "\\\\");
+                else
+                    Engine.Base.Compute.RecordError("The given file path does not exist.");
+
+                string endpoint = "doc/IMPORTMXT";
+                string jsonPayload = "{\"Argument\": \"" + filePath + "\"}";
+
+                await SendRequestAsync(endpoint, HttpMethod.Post, jsonPayload).ConfigureAwait(false);
+                return true;
+            }
+
+            else
+            {
+                Engine.Base.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter version.");
+                return false;
+            }
+        }
 
         public bool RunCommand(AnalyseLoadCases command)
         {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Adapter/pull/401
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #394 
Closes #399 

Adds a new Import ExecuteAction that allows the user to import a .mct or .mgt file into Midas NX based on a provided file path. 


### Test files
<!-- Link to test files to validate the proposed changes -->
[Basic test file](https://burohappold.sharepoint.com/:f:/s/BHoM/Em8FiFlO4G9OnU19dzOr1MABk2OISgdCSi78a6YxgFAV_Q?e=6zhvas)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `ImportFile` functionality to the adapter, this allows the user to import MCT files and other supported file types;
- Users can now push to text files as before, and then send load that MCT directly in to MidasCivil_NX using the `ExecuteAction`.

### Additional comments
Can be updated to also allow imports of json files if needed (different endpoints).