### PR TITLE
Fix bugs related to the upgrade to MidasCivil_NX

### DIFF
--- a/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToRigidLink.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToRigidLink.cs
@@ -54,6 +54,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 case "9.4.0":
                 case "9.4.5":
                 case "9.5.0":
+                case "9.5.0.nx":
                     primaryId = delimitted[0].Trim();
                     fixity = delimitted[1].Replace(" ", "");
                     secondaryIds = delimitted[2].Split(' ').Where(m => !string.IsNullOrWhiteSpace(m)).ToList();

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromRigidLink.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromRigidLink.cs
@@ -23,6 +23,8 @@
 using BH.oM.Adapters.MidasCivil;
 using BH.Engine.Adapter;
 using BH.oM.Structure.Elements;
+using BH.oM.Structure.Constraints;
+using System;
 
 namespace BH.Adapter.Adapters.MidasCivil
 {
@@ -34,6 +36,11 @@ namespace BH.Adapter.Adapters.MidasCivil
 
         public static string FromRigidLink(this RigidLink link, string version)
         {
+            LinkConstraint con = link.Constraint;
+
+            if (con.XtoYY || con.XtoZZ || con.YtoXX || con.YtoZZ || con.ZtoXX || con.ZtoYY)
+                Engine.Base.Compute.RecordError("Imposed rotations due to translations are not supported in this Adapter.");
+
             string midasLink = "";
 
             string primaryId = link.PrimaryNode.AdapterId<string>(typeof(MidasCivilId));
@@ -44,12 +51,12 @@ namespace BH.Adapter.Adapters.MidasCivil
                 secondaryId = secondaryId + " " + secondaryNode.AdapterId<string>(typeof(MidasCivilId));
             }
 
-            string fixity = BoolToFixity(link.Constraint.XtoX) +
-                            BoolToFixity(link.Constraint.YtoY) +
-                            BoolToFixity(link.Constraint.ZtoZ) +
-                            BoolToFixity(link.Constraint.XXtoXX) +
-                            BoolToFixity(link.Constraint.YYtoYY) +
-                            BoolToFixity(link.Constraint.ZZtoZZ);
+            string fixity = BoolToFixity(con.XtoX) +
+                            BoolToFixity(con.YtoY) +
+                            BoolToFixity(con.ZtoZ) +
+                            BoolToFixity(con.XXtoXX) +
+                            BoolToFixity(con.YYtoYY) +
+                            BoolToFixity(con.ZZtoZZ);
 
             switch (version)
             {

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromRigidLink.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Elements/FromRigidLink.cs
@@ -58,6 +58,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 case "9.4.0":
                 case "9.4.5":
                 case "9.5.0":
+                case "9.5.0.nx":
                     midasLink = primaryId + "," + fixity + "," + secondaryId + "," + link.Name;
                     break;
                 default:

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaUniformlyDistributedLoad.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromAreaUniformlyDistributedLoad.cs
@@ -48,6 +48,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                 case "9.1.0":
                 case "9.4.5":
                 case "9.5.0":
+                case "9.5.0.nx":
+
                     midasFEMeshLoad = assignedFEMesh + ", PRES, PLATE, FACE, " + FromLoadAxis(femeshLoad.Axis) + direction +
                                 ", 0, 0, 0, " + FromLoadProjection(femeshLoad.Projected) + ", " +
                                 FromVectorDirection(femeshLoad.Pressure, direction).PressureFromSI(forceUnit, lengthUnit).ToString() +

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromLoadCombination.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromLoadCombination.cs
@@ -44,6 +44,11 @@ namespace BH.Adapter.Adapters.MidasCivil
                 case "8.6.5":
                     line1 = "NAME=" + loadCombination.Name + ", GEN, ACTIVE, 0, 0, , 0, 0";
                     break;
+                case "9.4.5":
+                case "9.5.0":
+                case "9.5.0.nx":
+                    line1 = "NAME=" + loadCombination.Name + ", GEN, ACTIVE, 0, 0, , 0, 0, 0, 1";
+                    break;
                 default:
                     line1 = "NAME=" + loadCombination.Name + ", GEN, ACTIVE, 0, 0, , 0, 0, 0";
                     break;

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromPointForce.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Loads/FromPointForce.cs
@@ -41,6 +41,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 case "9.1.0":
                 case "9.4.5":
                 case "9.5.0":
+                case "9.5.0.nx":
                     midasPointLoad = assignedNode + "," + pointLoad.Force.X.ForceFromSI(forceUnit).ToString() +
                                                     "," + pointLoad.Force.Y.ForceFromSI(forceUnit).ToString() +
                                                     "," + pointLoad.Force.Z.ForceFromSI(forceUnit).ToString() +


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #398 

<!-- Add short description of what has been fixed -->
As a new Midas Civil version was added to use the new API feature the old versioning for 9.5.0 was lost, this adds version 9.5.0.nx where it is needed to create a mct file with the right format.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/MidasCivil_Toolkit/%23401-AddMidasCivilNXversioning/BuroHappold_BHoM_v8.0.beta_Create%20read%20loads%20(1).gh?csf=1&web=1&e=NgCEyd 

### Changelog
- Fixed a bug in NX where `AreaUniformlyDistributedLoad` and `PointForce` were not been parsed in Midas;
- Fixed a bug in NX where `RigidLink` was not being parsed in Midas;
- Fixed a bug in where `LoadCombination` was not being parsed in Midas;

<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->