### PR TITLE
Update the push/pull of TaperedProfile

### DIFF
--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -110,8 +110,8 @@ namespace BH.Adapter.MidasCivil
                 else if (type == "TAPERED")
                 {
                     List<string> profiles = sectionProperties[index + 1].Split(',').ToList();
-                    string shape = split[14].Trim();
-                    string interpolationOrder = Math.Max(System.Convert.ToInt32(split[15].Trim()), System.Convert.ToInt32(split[16].Trim())).ToString();
+                    string shape = split[15].Trim();
+                    string interpolationOrder = Math.Max(System.Convert.ToInt32(split[16].Trim()), System.Convert.ToInt32(split[17].Trim())).ToString();
 
                     bhomSectionProperty = Adapters.MidasCivil.Convert.ToSectionProperty(profiles, "TAPERED" + "-" + shape + "-" + interpolationOrder, m_lengthUnit);
 

--- a/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter.MidasCivil
             for (int i = 0; i < sectionProperties.Count; i++)
             {
                 string line = sectionProperties[i];
-                if(!(line.Length < 2))
+                if (!(line.Length < 2))
                 {
                     if (types.Any(x => x == sectionProperties[i].Split(',')[1].Trim()))
                         indexes.Add(i);
@@ -89,7 +89,7 @@ namespace BH.Adapter.MidasCivil
                     if (numberColumns == 16)
                     {
                         // delimitted[15] is the database name of the section
-                        bhomSectionProperty = (ISectionProperty)Engine.Library.Query.Match("Structure\\SectionProperties",split[15]);
+                        bhomSectionProperty = (ISectionProperty)Engine.Library.Query.Match("Structure\\SectionProperties", split[15]);
                         if (bhomSectionProperty == null)
                             Engine.Base.Compute.RecordWarning("The database section " + split[2] + " could not be found in the BHoM datasets - a null value has been assigned.");
                         else
@@ -166,7 +166,7 @@ namespace BH.Adapter.MidasCivil
                         // Inner polylines always follow outer, find the start of the next IPOLY otherwise it's the end of the PSC Section
                         int iPolyStart = iOPolyEnd + 1;
                         int iPolyEnd = -2;
-                        if(!(iPolyStart + 1 > pscSectionProperty.Count - 1))
+                        if (!(iPolyStart + 1 > pscSectionProperty.Count - 1))
                             iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY")) - 1;
 
                         // This is the case where IPOLY is contained on a single line (i.e. three points)
@@ -181,18 +181,18 @@ namespace BH.Adapter.MidasCivil
                             // Get indexes for next polyline, IF statement to avoid out of index if there is a single IPOLY
                             iPolyStart = iPolyEnd + 1;
                             //This is the last IPOLY
-                            if(iPolyStart > pscSectionProperty.Count() -1)
+                            if (iPolyStart > pscSectionProperty.Count() - 1)
                                 iPolyEnd = -2;
                             else
                                 iPolyEnd = pscSectionProperty.FindIndex(iPolyStart + 1, x => x.Contains("IPOLY")) - 1;
                         }
 
                         // For the final inner polyline contained on a single line
-                        if (iPolyStart == pscSectionProperty.Count -1 && iPolyEnd == -2)
+                        if (iPolyStart == pscSectionProperty.Count - 1 && iPolyEnd == -2)
                         {
                             iPolyEnd = pscSectionProperty.Count - 1;
                             polys.Add(new Polyline() { ControlPoints = ParsePoints(pscSectionProperty, iPolyStart, iPolyEnd, "IPOLY") });
-                        }    
+                        }
 
                     }
 

--- a/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
+++ b/MidasCivil_Adapter/Convert/ToMidasCivil/Properties/FromSectionProperty.cs
@@ -65,7 +65,7 @@ namespace BH.Adapter.Adapters.MidasCivil
                 {
                     midasSectionProperty.Add(sectionProperty.AdapterId<string>(typeof(MidasCivilId)) + ",TAPERED," +
                         new string(sectionProperty.DescriptionOrName().Replace(",", "").Take(sectionPropertyCharacterLimit).ToArray()) +
-                        ",CC, 0,0,0,0,0,0,0,0,YES,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
+                        ",CC, 0,0,0,0,0,0,0,0,YES,NO,NO," + GetSectionShapeCode(sectionProperty) + "," + GetInterpolationOrder(sectionProperty) +
                         "," + GetInterpolationOrder(sectionProperty) + ",USER");
                     midasSectionProperty.Add(CreateProfile(sectionProperty.SectionProfile as dynamic, lengthUnit));
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #408 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Script](https://burohappold.sharepoint.com/:u:/s/BHoM/EaMJdV5oX-tIm-_YaYlmG-gBHNQVI43pPN4tsP9C8e0ovg?e=ZCEcAf)
[Installer](https://burohappold.sharepoint.com/:f:/s/BHoM/Eowt_Cpn7LJAhKvLsOqB998BPmTKCK50jy4aWdb5fu_c-g?e=z9vtKZ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Updates the way `TaperedProfile` is pushed and pulled from MidasCivil. An additional parameter has been added to TAPERED, this is from at least MidasCivil 2023 v1.1 (9.4.0).

### Additional comments
<!-- As required -->