### PR TITLE
Add warning for BarPointLoad where only parametric ditances are supported

### DIFF
--- a/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
+++ b/MidasCivil_Adapter/CRUD/Create/Loads/BarPointLoads.cs
@@ -91,6 +91,8 @@ namespace BH.Adapter.MidasCivil
                 CompareLoadGroup(midasLoadGroup, loadGroupPath);
                 RemoveEndOfDataString(barLoadPath);
                 File.AppendAllLines(barLoadPath, midasBarLoads);
+
+                Compute.RecordWarning("MidasCivil only supports parametric distances with BarPointLoads.");
             }
 
             return true;


### PR DESCRIPTION

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #414 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Push/Pull loads test script.

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/MidasCivil_Toolkit/%23415-AddWarningForBarPointLoadPosition?csf=1&web=1&e=2EtCOe

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->