### PR TITLE
Added new versions of Midas NX

### DIFF
--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -86,6 +86,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     string endpoint = "doc/NEW";
                     string jsonPayload = "{\"Argument\": {}}";
                     await SendRequestAsync(endpoint, HttpMethod.Post, jsonPayload).ConfigureAwait(false);
@@ -136,6 +138,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     string endpoint = "doc/SAVE";
                     string jsonPayload = "{\"Argument\": {}}";
 
@@ -163,6 +167,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     string filePath = newDirectory.Replace("\\", "\\\\");
 
                     string endpoint = "doc/SAVEAS";
@@ -206,6 +212,8 @@ namespace BH.Adapter.MidasCivil
                 {
                     case "9.5.0.nx":
                     case "9.5.5.nx":
+                    case "9.6.0.nx":
+                    case "9.7.5.nx":
                         if (File.Exists(filePath))
                             filePath = filePath.Replace("\\", "\\\\");
                         else
@@ -330,6 +338,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     string endpoint = "doc/ANAL";
                     string jsonPayload = "{}";
 
@@ -348,6 +358,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     string endpoint = "";
                     string filePath = command.FilePath;
 
@@ -414,7 +426,6 @@ namespace BH.Adapter.MidasCivil
         private string GetDirectoryRoot(string directory)
         {
             List<string> directoryRoot = m_directory.Split('\\').ToList();
-            directoryRoot.RemoveAt(directoryRoot.Count - 1);
 
             return String.Join("\\", directoryRoot.ToArray());
         }

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -266,21 +266,6 @@ namespace BH.Adapter.MidasCivil
                             }
                         }
 
-                        string fileName = Path.GetFileNameWithoutExtension(filePath);
-                        string txtFile = m_directory + "\\" + fileName + ".txt";
-                        string mctFile = m_directory + "\\" + fileName + ".mct";
-
-                        if (File.Exists(txtFile))
-                        {
-                            m_midasText = File.ReadAllLines(txtFile).ToList();
-                            SetSectionText();
-                        }
-                        else if (File.Exists(mctFile))
-                        {
-                            m_midasText = File.ReadAllLines(mctFile).ToList();
-                            SetSectionText();
-                        }
-
                         string versionFile = m_directory + "\\TextFiles\\" + "VERSION" + ".txt";
                         if (!(m_midasCivilVersion == ""))
                         {
@@ -325,6 +310,20 @@ namespace BH.Adapter.MidasCivil
 
                         Directory.CreateDirectory(m_directory + "\\Results");
                         break;
+                }
+                string fileName = Path.GetFileNameWithoutExtension(filePath);
+                string txtFile = m_directory + "\\" + fileName + ".txt";
+                string mctFile = m_directory + "\\" + fileName + ".mct";
+
+                if (File.Exists(txtFile))
+                {
+                    m_midasText = File.ReadAllLines(txtFile).ToList();
+                    SetSectionText();
+                }
+                else if (File.Exists(mctFile))
+                {
+                    m_midasText = File.ReadAllLines(mctFile).ToList();
+                SetSectionText();
                 }
             }
             return true;

--- a/MidasCivil_Adapter/AdapterActions/Execute.cs
+++ b/MidasCivil_Adapter/AdapterActions/Execute.cs
@@ -93,7 +93,7 @@ namespace BH.Adapter.MidasCivil
                     await SendRequestAsync(endpoint, HttpMethod.Post, jsonPayload).ConfigureAwait(false);
                     break;
                 default:
-                    string newDirectory = GetDirectoryRoot(m_directory) + "\\Untitled";
+                    string newDirectory = m_directory + "\\Untitled";
 
                     bool directoryExists = Directory.Exists(newDirectory);
 
@@ -156,7 +156,7 @@ namespace BH.Adapter.MidasCivil
         public async Task<bool> RunCommand(SaveAs command)
         {
             string fileName = command.FileName;
-            string newDirectory = GetDirectoryRoot(m_directory) + "\\" + fileName;
+            string newDirectory = m_directory + "\\" + fileName;
 
             if (Directory.Exists(newDirectory))
             {
@@ -418,16 +418,6 @@ namespace BH.Adapter.MidasCivil
         {
             Engine.Base.Compute.RecordWarning($"The command {command.GetType().Name} is not supported by this Adapter.");
             return false;
-        }
-
-        /***************************************************/
-        /**** Private helper methods                    ****/
-        /***************************************************/
-        private string GetDirectoryRoot(string directory)
-        {
-            List<string> directoryRoot = m_directory.Split('\\').ToList();
-
-            return String.Join("\\", directoryRoot.ToArray());
         }
 
         private static void CopyAll(DirectoryInfo sourceDirectory, DirectoryInfo targetDirectory)

--- a/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/BarResults.cs
@@ -48,6 +48,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     List<string> loadCasesNX = Task.Run(() => AppendCaseTypes(request)).Result;
                     string divisions = SetBarDivisions(request);
 

--- a/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -47,6 +47,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     List<string> loadCasesNX = Task.Run(() => AppendCaseTypes(request)).Result;
                     if (loadCasesNX != null)
                         results = Task.Run(() => ReadResult(request.ResultType.ToString(), objectIds, loadCasesNX, "", request)).Result.ToList();

--- a/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -49,6 +49,8 @@ namespace BH.Adapter.MidasCivil
             {
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     List<string> loadCasesNX = Task.Run(() => AppendCaseTypes(request)).Result;
                     if (loadCasesNX != null)
                         results = Task.Run(() => ReadResult(request.ResultType.ToString(), objectIds, loadCasesNX)).Result.ToList();

--- a/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/MidasCivil_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -53,6 +53,8 @@ namespace BH.Adapter.MidasCivil
                 {
                     case "9.5.0.nx":
                     case "9.5.5.nx":
+                    case "9.6.0.nx":
+                    case "9.7.5.nx":
                         List<int> emptyIds = new List<int>();
                         return emptyIds;
                     default:

--- a/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToRigidLink.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Elements/ToRigidLink.cs
@@ -56,6 +56,8 @@ namespace BH.Adapter.Adapters.MidasCivil
                 case "9.5.0":
                 case "9.5.0.nx":
                 case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
                     primaryId = delimitted[0].Trim();
                     fixity = delimitted[1].Replace(" ", "");
                     secondaryIds = delimitted[2].Split(' ').Where(m => !string.IsNullOrWhiteSpace(m)).ToList();

--- a/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/MidasCivil_Adapter/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -42,9 +42,9 @@ namespace BH.Adapter.Adapters.MidasCivil
 
             if (int.TryParse(assignment, out constraint))
             {
-                foreach (char freedom in assignment)
+                for (int i = 0; i < 6; i++)
                 {
-                    int freedoms = int.Parse(freedom.ToString());
+                    int freedoms = int.Parse(assignment[i].ToString());
                     if (freedoms == 1)
                     {
                         fixity.Add(true);

--- a/MidasCivil_Adapter/MidasCivilAdapter.cs
+++ b/MidasCivil_Adapter/MidasCivilAdapter.cs
@@ -110,6 +110,8 @@ namespace BH.Adapter.MidasCivil
                 {
                     case "9.5.0.nx":
                     case "9.5.5.nx":
+                    case "9.6.0.nx":
+                    case "9.7.5.nx":
                         if (midasCivilSettings.mApiKey != null)
                             m_mapiKey = midasCivilSettings.mApiKey;
                         else

--- a/MidasCivil_Adapter/PrivateHelpers/ReadResult.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/ReadResult.cs
@@ -128,11 +128,14 @@ namespace BH.Adapter.MidasCivil
                 case "NodeReaction":
                     switch (m_midasCivilVersion)
                     {
-                        case "9.5.0.nx":
-                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("Reaction(Global)")?.PropertyValue("DATA");
-                            break;
-                        default:
+                        case "9.5.5.nx":
                             data = parsedJson.PropertyValue("CustomData")?.PropertyValue("ReactionGlobal")?.PropertyValue("DATA");
+                            break;
+                        case "9.5.0.nx":
+                        case "9.6.0.nx":
+                        case "9.7.5.nx":
+                        default:
+                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("Reaction(Global)")?.PropertyValue("DATA");
                             break;
                     }
                     resultItems = data as List<List<object>>;
@@ -145,11 +148,14 @@ namespace BH.Adapter.MidasCivil
                 case "NodeDisplacement":
                     switch (m_midasCivilVersion)
                     {
-                        case "9.5.0.nx":
-                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("Displacements(Global)")?.PropertyValue("DATA");
-                            break;
-                        default:
+                        case "9.5.5.nx":
                             data = parsedJson.PropertyValue("CustomData")?.PropertyValue("DisplacementsGlobal")?.PropertyValue("DATA");
+                            break;
+                        case "9.5.0.nx":
+                        case "9.6.0.nx":
+                        case "9.7.5.nx":
+                        default:
+                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("Displacements(Global)")?.PropertyValue("DATA");
                             break;
                     }
                     resultItems = data as List<List<object>>;
@@ -171,11 +177,14 @@ namespace BH.Adapter.MidasCivil
                 case "Forces":
                     switch (m_midasCivilVersion)
                     {
-                        case "9.5.0.nx":
-                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateForce(UnitLength:Local)")?.PropertyValue("DATA");
-                            break;
-                        default:
+                        case "9.5.5.nx":
                             data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateForceUnitLengthLocal")?.PropertyValue("DATA");
+                            break;
+                        case "9.5.0.nx":
+                        case "9.6.0.nx":
+                        case "9.7.5.nx":
+                        default:
+                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateForce(UnitLength:Local)")?.PropertyValue("DATA");
                             break;
                     }
                     resultItems = data as List<List<object>>;
@@ -185,11 +194,14 @@ namespace BH.Adapter.MidasCivil
                 case "Stresses":
                     switch (m_midasCivilVersion)
                     {
-                        case "9.5.0.nx":
-                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateStress(Local)")?.PropertyValue("DATA");
-                            break;
-                        default:
+                        case "9.5.5.nx":
                             data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateStressLocal")?.PropertyValue("DATA");
+                            break;
+                        case "9.5.0.nx":
+                        case "9.6.0.nx":
+                        case "9.7.5.nx":
+                        default:
+                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateStress(Local)")?.PropertyValue("DATA");
                             break;
                     }
                     resultItems = data as List<List<object>>;
@@ -203,11 +215,14 @@ namespace BH.Adapter.MidasCivil
                 case "VonMises":
                     switch (m_midasCivilVersion)
                     {
-                        case "9.5.0.nx":
-                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateStress(Local)")?.PropertyValue("DATA");
-                            break;
-                        default:
+                        case "9.5.5.nx":
                             data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateStressLocal")?.PropertyValue("DATA");
+                            break;
+                        case "9.5.0.nx":
+                        case "9.6.0.nx":
+                        case "9.7.5.nx":
+                        default:
+                            data = parsedJson.PropertyValue("CustomData")?.PropertyValue("PlateStress(Local)")?.PropertyValue("DATA");
                             break;
                     }
                     resultItems = data as List<List<object>>;

--- a/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
+++ b/MidasCivil_Adapter/PrivateHelpers/SetSectionText.cs
@@ -43,10 +43,25 @@ namespace BH.Adapter.MidasCivil
                 .Select(x => x.index)
                 .ToList();
 
-            List<int> loadcaseEnds = m_midasText.Select((value, index) => new { value, index })
-                .Where(x => x.ToString().Contains("; End of data for load case"))
-                .Select(x => x.index)
-                .ToList();
+            List<int> loadcaseEnds = new List<int>();
+            switch (m_midasCivilVersion)
+            {
+                case "9.5.0.nx":
+                case "9.5.5.nx":
+                case "9.6.0.nx":
+                case "9.7.5.nx":
+                    loadcaseEnds = m_midasText.Select((value, index) => new { value, index })
+                        .Where(x => x.ToString().Contains("] -------------------------"))
+                        .Select(x => x.index)
+                        .ToList();
+                    break;
+                default:
+                    loadcaseEnds = m_midasText.Select((value, index) => new { value, index })
+                        .Where(x => x.ToString().Contains("; End of data for load case"))
+                        .Select(x => x.index)
+                        .ToList();
+                    break;
+            }
 
             List<int> loadcaseRange = new List<int>();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #431

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FMidasCivil%5FToolkit%2F%23431%2DAddSupportForMidasCivil2026&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&csf=1&CID=1b8d79f1%2Df678%2D4ea8%2D95eb%2Dcf4af160e084&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Added new versions of Midas to all switch cases that depends on the versioning. Reading result is the only part where different versions of Midas Civil NX works differently, tests have been done for version: 9.5.5, 9.60 and 9.7.5. 
- When using the execute commands “SaveAs” and “NewModel”, the newly created file is saved in the same folder as the MIDAS project file, instead of being placed in the parent folder above the MIDAS project file.

### Additional comments
<!-- As required -->